### PR TITLE
Expose batch_exp on part of array

### DIFF
--- a/libff/algebra/curves/edwards/edwards_g2.cpp
+++ b/libff/algebra/curves/edwards/edwards_g2.cpp
@@ -110,7 +110,7 @@ void edwards_G2::to_special()
         return;
     }
 
-#ifdef DEBUG
+#if defined(DEBUG) && !defined(NDEBUG)
     const edwards_G2 copy(*this);
 #endif
 

--- a/libff/algebra/fields/bigint.tcc
+++ b/libff/algebra/fields/bigint.tcc
@@ -36,6 +36,7 @@ bigint<n>::bigint(const char* s) /// Initialize from a string containing an inte
 
     mp_size_t limbs_written = mpn_set_str(this->data, s_copy, l, 10);
     assert(limbs_written <= n);
+    UNUSED(limbs_written);
 
     delete[] s_copy;
 }
@@ -216,6 +217,7 @@ std::istream& operator>>(std::istream &in, bigint<n> &b)
 
     mp_size_t limbs_written = mpn_set_str(b.data, s_copy, l, 10);
     assert(limbs_written <= n);
+    UNUSED(limbs_written);
 
     delete[] s_copy;
 #endif

--- a/libff/algebra/fields/fp.tcc
+++ b/libff/algebra/fields/fp.tcc
@@ -180,6 +180,7 @@ void Fp_model<n,modulus>::mul_reduce(const bigint<n> &other)
         {
             const mp_limb_t borrow = mpn_sub(res+n, res+n, n, modulus.data, n);
             assert(borrow == 0);
+            UNUSED(borrow);
         }
 
         mpn_copyi(this->mont_repr.data, res+n, n);
@@ -205,6 +206,7 @@ Fp_model<n,modulus>::Fp_model(const long x, const bool is_unsigned)
     {
         const mp_limb_t borrow = mpn_sub_1(this->mont_repr.data, modulus.data, n, (mp_limb_t)-x);
         assert(borrow == 0);
+        UNUSED(borrow);
     }
 
     mul_reduce(Rsquared);
@@ -411,6 +413,7 @@ Fp_model<n,modulus>& Fp_model<n,modulus>::operator+=(const Fp_model<n,modulus>& 
         {
             const mp_limb_t borrow = mpn_sub(scratch, scratch, n+1, modulus.data, n);
             assert(borrow == 0);
+            UNUSED(borrow);
         }
 
         mpn_copyi(this->mont_repr.data, scratch, n);
@@ -503,6 +506,7 @@ Fp_model<n,modulus>& Fp_model<n,modulus>::operator-=(const Fp_model<n,modulus>& 
 
         const mp_limb_t borrow = mpn_sub(scratch, scratch, n+1, other.mont_repr.data, n);
         assert(borrow == 0);
+        UNUSED(borrow);
 
         mpn_copyi(this->mont_repr.data, scratch, n);
     }
@@ -657,6 +661,7 @@ Fp_model<n,modulus>& Fp_model<n,modulus>::invert()
     /* computes gcd(u, v) = g = u*s + v*t, so s*u will be 1 (mod v) */
     const mp_size_t gn = mpn_gcdext(g.data, s, &sn, this->mont_repr.data, n, v.data, n);
     assert(gn == 1 && g.data[0] == 1); /* inverse exists */
+    UNUSED(gn);
 
     mp_limb_t q; /* division result fits into q, as sn <= n+1 */
     /* sn < 0 indicates negative sn; will fix up later */
@@ -678,6 +683,7 @@ Fp_model<n,modulus>& Fp_model<n,modulus>::invert()
     {
         const mp_limb_t borrow = mpn_sub_n(this->mont_repr.data, modulus.data, this->mont_repr.data, n);
         assert(borrow == 0);
+        UNUSED(borrow);
     }
 
     mul_reduce(Rcubed);

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -117,6 +117,13 @@ std::vector<T> batch_exp(const size_t scalar_size,
                          const std::vector<FieldT> &v);
 
 template<typename T, typename FieldT>
+std::vector<T> batch_exp(const size_t scalar_size,
+                         const size_t window,
+                         const window_table<T> &table,
+                         const std::vector<FieldT> &v,
+                         size_t num_entries);
+
+template<typename T, typename FieldT>
 std::vector<T> batch_exp_with_coeff(const size_t scalar_size,
                                     const size_t window,
                                     const window_table<T> &table,

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -136,6 +136,7 @@ T multi_exp_inner(
         result = result + opt_window_wnaf_exp(*vec_it, scalar_bigint, scalar_bigint.num_bits());
     }
     assert(scalar_it == scalar_end);
+    UNUSED(scalar_end);
 
     return result;
 }
@@ -158,6 +159,7 @@ T multi_exp_inner(
         result = result + (*scalar_it) * (*vec_it);
     }
     assert(scalar_it == scalar_end);
+    UNUSED(scalar_end);
 
     return result;
 }
@@ -448,6 +450,7 @@ T multi_exp_with_mixed_addition(typename std::vector<T>::const_iterator vec_star
                                 const size_t chunks)
 {
     assert(std::distance(vec_start, vec_end) == std::distance(scalar_start, scalar_end));
+    UNUSED(vec_end);
     enter_block("Process scalar vector");
     auto value_it = vec_start;
     auto scalar_it = scalar_start;

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -620,16 +620,26 @@ std::vector<T> batch_exp(const size_t scalar_size,
                          const window_table<T> &table,
                          const std::vector<FieldT> &v)
 {
+    return batch_exp(scalar_size, window, table, v, v.size());
+}
+
+template<typename T, typename FieldT>
+std::vector<T> batch_exp(const size_t scalar_size,
+                         const size_t window,
+                         const window_table<T> &table,
+                         const std::vector<FieldT> &v,
+                         size_t num_entries)
+{
     if (!inhibit_profiling_info)
     {
         print_indent();
     }
-    std::vector<T> res(v.size(), table[0][0]);
+    std::vector<T> res(num_entries, table[0][0]);
 
 #ifdef MULTICORE
 #pragma omp parallel for
 #endif
-    for (size_t i = 0; i < v.size(); ++i)
+    for (size_t i = 0; i < num_entries; ++i)
     {
         res[i] = windowed_exp(scalar_size, window, table, v[i]);
 

--- a/libff/common/profiling.cpp
+++ b/libff/common/profiling.cpp
@@ -344,6 +344,7 @@ void print_mem(const std::string &s)
         printf("* Peak vsize (physical memory+swap) in mebibytes (%s): %lu\n", s.c_str(), usage.vsize >> 20);
     }
 #else
+    UNUSED(s);
     printf("* Memory profiling not supported in NO_PROCPS mode\n");
 #endif
 }


### PR DESCRIPTION
Small interface change to support running batch_exp on the first `n` elements of an array, which saves having to unnecessarily copy huge subarrays around.