### PR TITLE
Consistent use of separator in Fp2 streaming

### DIFF
--- a/libff/algebra/fields/fp2.tcc
+++ b/libff/algebra/fields/fp2.tcc
@@ -207,7 +207,7 @@ Fp2_model<n,modulus> Fp2_model<n,modulus>::operator^(const bigint<m> &pow) const
 template<mp_size_t n, const bigint<n>& modulus>
 std::ostream& operator<<(std::ostream &out, const Fp2_model<n, modulus> &el)
 {
-    out << el.c0 << OUTPUT_SEPARATOR << el.c1;
+    out << el.c0 << el.c1;
     return out;
 }
 


### PR DESCRIPTION
I hit a very strange problem in clearmatics/zeth#67 where some tests related to serialization could fail on some platforms (linux travis build failed, whereas mac ran fine).

After investigating, it turned out that disabling certain calls to `operator<<(std::ostream &, const Fp2<ppT> &v)` allowed the tests to pass.  Removing the SEPARATOR serialization fixed all the test errors.  I'm unusure exactly what is going on here and even after trying many combinations of things I didn't get a satisfactory reproducible (the best experiment I was able to do was enabling / disabling the use of `<<` when printing out the hex representation of the Fp2 elements.  So, given that the separator is defined as the empty string, but my best guess is that this is related to text/binary stream differences across stl implementations.

I did not look further into it yet, but I can if that would be valuable.  For now, removing the SEPARATOR seems to be a valid change, as there is no matching `consume_SEPARATOR` in the corresponding `>>` operator.