### PR TITLE
G1 and G2 compressed and uncompressed serialization

### DIFF
--- a/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g1.hpp
@@ -15,10 +15,6 @@
 namespace libff {
 
 class alt_bn128_G1;
-void alt_bn128_G1_write_uncompressed(std::ostream &out, const alt_bn128_G1 &g);
-void alt_bn128_G1_read_uncompressed(std::istream &in, alt_bn128_G1 &out);
-void alt_bn128_G1_write_compressed(std::ostream &out, const alt_bn128_G1 &g);
-void alt_bn128_G1_read_compressed(std::istream &in, alt_bn128_G1 &out);
 std::ostream& operator<<(std::ostream &, const alt_bn128_G1&);
 std::istream& operator>>(std::istream &, alt_bn128_G1&);
 
@@ -72,8 +68,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const alt_bn128_G1 &g);
-    friend std::istream& operator>>(std::istream &in, alt_bn128_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, alt_bn128_G1 &);
+    static void read_compressed(std::istream &, alt_bn128_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<alt_bn128_G1> &vec);
 };
@@ -89,9 +87,6 @@ alt_bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const alt_bn128_G1 &rhs
 {
     return scalar_mul<alt_bn128_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<alt_bn128_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<alt_bn128_G1> &v);
 
 } // libff
 #endif // ALT_BN128_G1_HPP_

--- a/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_g2.hpp
@@ -15,10 +15,6 @@
 namespace libff {
 
 class alt_bn128_G2;
-void alt_bn128_G2_write_uncompressed(std::ostream &out, const alt_bn128_G2 &g);
-void alt_bn128_G2_read_uncompressed(std::istream &in, alt_bn128_G2 &out);
-void alt_bn128_G2_write_compressed(std::ostream &out, const alt_bn128_G2 &g);
-void alt_bn128_G2_read_compressed(std::istream &in, alt_bn128_G2 &out);
 std::ostream& operator<<(std::ostream &, const alt_bn128_G2&);
 std::istream& operator>>(std::istream &, alt_bn128_G2&);
 
@@ -76,8 +72,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const alt_bn128_G2 &g);
-    friend std::istream& operator>>(std::istream &in, alt_bn128_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, alt_bn128_G2 &);
+    static void read_compressed(std::istream &, alt_bn128_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<alt_bn128_G2> &vec);
 };

--- a/libff/algebra/curves/bls12_377/bls12_377_g1.cpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g1.cpp
@@ -401,31 +401,49 @@ bls12_377_G1 bls12_377_G1::random_element()
     return (scalar_field::random_element().as_bigint()) * G1_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const bls12_377_G1 &g)
+void bls12_377_G1::write_uncompressed(std::ostream &out) const
 {
-    bls12_377_G1 copy(g);
+    bls12_377_G1 copy(*this);
     copy.to_affine_coordinates();
-
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, bls12_377_G1 &g)
+void bls12_377_G1::write_compressed(std::ostream &out) const
+{
+    bls12_377_G1 copy(*this);
+    copy.to_affine_coordinates();
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
+}
+
+void bls12_377_G1::read_uncompressed(std::istream &in, bls12_377_G1 &g)
 {
     char is_zero;
     bls12_377_Fq tX, tY;
 
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using Jacobian coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = bls12_377_Fq::one();
+    }
+    else
+    {
+        g = bls12_377_G1::zero();
+    }
+}
+
+void bls12_377_G1::read_compressed(std::istream &in, bls12_377_G1 &g)
+{
+    char is_zero;
+    bls12_377_Fq tX, tY;
+
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -448,7 +466,7 @@ std::istream& operator>>(std::istream &in, bls12_377_G1 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using Jacobian coordinates
     if (!is_zero)
     {
@@ -460,39 +478,25 @@ std::istream& operator>>(std::istream &in, bls12_377_G1 &g)
     {
         g = bls12_377_G1::zero();
     }
-
-    return in;
 }
 
-std::ostream& operator<<(std::ostream& out, const std::vector<bls12_377_G1> &v)
+std::ostream& operator<<(std::ostream &out, const bls12_377_G1 &g)
 {
-    out << v.size() << "\n";
-    for (const bls12_377_G1& t : v)
-    {
-        out << t << OUTPUT_NEWLINE;
-    }
-
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
     return out;
 }
 
-std::istream& operator>>(std::istream& in, std::vector<bls12_377_G1> &v)
+std::istream& operator>>(std::istream &in, bls12_377_G1 &g)
 {
-    v.clear();
-
-    size_t s;
-    in >> s;
-    consume_newline(in);
-
-    v.reserve(s);
-
-    for (size_t i = 0; i < s; ++i)
-    {
-        bls12_377_G1 g;
-        in >> g;
-        consume_OUTPUT_NEWLINE(in);
-        v.emplace_back(g);
-    }
-
+#ifdef NO_PT_COMPRESSION
+    bls12_377_G1::read_uncompressed(in, g);
+#else
+    bls12_377_G1::read_compressed(in, g);
+#endif
     return in;
 }
 

--- a/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
@@ -68,8 +68,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const bls12_377_G1 &g);
-    friend std::istream& operator>>(std::istream &in, bls12_377_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, bls12_377_G1 &);
+    static void read_compressed(std::istream &, bls12_377_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<bls12_377_G1> &vec);
 };
@@ -85,9 +87,6 @@ bls12_377_G1 operator*(const Fp_model<m,modulus_p> &lhs, const bls12_377_G1 &rhs
 {
     return scalar_mul<bls12_377_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<bls12_377_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<bls12_377_G1> &v);
 
 } // libff
 #endif // BLS12_377_G1_HPP_

--- a/libff/algebra/curves/bls12_377/bls12_377_g2.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g2.hpp
@@ -72,8 +72,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const bls12_377_G2 &g);
-    friend std::istream& operator>>(std::istream &in, bls12_377_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, bls12_377_G2 &);
+    static void read_compressed(std::istream &, bls12_377_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<bls12_377_G2> &vec);
 };

--- a/libff/algebra/curves/bn128/bn128_g1.cpp
+++ b/libff/algebra/curves/bn128/bn128_g1.cpp
@@ -348,35 +348,6 @@ bn128_G1 bn128_G1::random_element()
     return bn128_Fr::random_element().as_bigint() * G1_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const bn128_G1 &g)
-{
-    bn128_G1 gcopy(g);
-    gcopy.to_affine_coordinates();
-
-    out << (gcopy.is_zero() ? '1' : '0') << OUTPUT_SEPARATOR;
-
-#ifdef NO_PT_COMPRESSION
-    /* no point compression case */
-#ifndef BINARY_OUTPUT
-    out << gcopy.X << OUTPUT_SEPARATOR << gcopy.Y;
-#else
-    out.write((char*) &gcopy.X, sizeof(gcopy.X));
-    out.write((char*) &gcopy.Y, sizeof(gcopy.Y));
-#endif
-
-#else
-    /* point compression case */
-#ifndef BINARY_OUTPUT
-    out << gcopy.X;
-#else
-    out.write((char*) &gcopy.X, sizeof(gcopy.X));
-#endif
-    out << OUTPUT_SEPARATOR << (((unsigned char*)&gcopy.Y)[0] & 1 ? '1' : '0');
-#endif
-
-    return out;
-}
-
 bool bn128_G1::is_well_formed() const
 {
     if (this->is_zero())
@@ -408,15 +379,43 @@ bool bn128_G1::is_well_formed() const
     }
 }
 
-std::istream& operator>>(std::istream &in, bn128_G1 &g)
+void bn128_G1::write_uncompressed(std::ostream &out) const
+{
+    bn128_G1 gcopy(*this);
+    gcopy.to_affine_coordinates();
+
+    out << (gcopy.is_zero() ? '1' : '0') << OUTPUT_SEPARATOR;
+
+#ifndef BINARY_OUTPUT
+    out << gcopy.X << OUTPUT_SEPARATOR << gcopy.Y;
+#else
+    out.write((char*) &gcopy.X, sizeof(gcopy.X));
+    out.write((char*) &gcopy.Y, sizeof(gcopy.Y));
+#endif
+}
+
+void bn128_G1::write_compressed(std::ostream &out) const
+{
+    bn128_G1 gcopy(*this);
+    gcopy.to_affine_coordinates();
+
+    out << (gcopy.is_zero() ? '1' : '0') << OUTPUT_SEPARATOR;
+
+#ifndef BINARY_OUTPUT
+    out << gcopy.X;
+#else
+    out.write((char*) &gcopy.X, sizeof(gcopy.X));
+#endif
+    out << OUTPUT_SEPARATOR << (((unsigned char*)&gcopy.Y)[0] & 1 ? '1' : '0');
+}
+
+void bn128_G1::read_uncompressed(std::istream &in, bn128_G1 &g)
 {
     char is_zero;
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
 
-#ifdef NO_PT_COMPRESSION
-    /* no point compression case */
 #ifndef BINARY_OUTPUT
     in >> g.X;
     consume_OUTPUT_SEPARATOR(in);
@@ -426,8 +425,24 @@ std::istream& operator>>(std::istream &in, bn128_G1 &g)
     in.read((char*) &g.Y, sizeof(g.Y));
 #endif
 
-#else
-    /* point compression case */
+    /* finalize */
+    if (!is_zero)
+    {
+        g.Z = bn::Fp(1);
+    }
+    else
+    {
+        g = bn128_G1::zero();
+    }
+}
+
+void bn128_G1::read_compressed(std::istream &in, bn128_G1 &g)
+{
+    char is_zero;
+    in.read((char*)&is_zero, 1); // this reads is_zero;
+    is_zero -= '0';
+    consume_OUTPUT_SEPARATOR(in);
+
     bn::Fp tX;
 #ifndef BINARY_OUTPUT
     in >> tX;
@@ -454,7 +469,6 @@ std::istream& operator>>(std::istream &in, bn128_G1 &g)
             bn::Fp::neg(g.Y, g.Y);
         }
     }
-#endif
 
     /* finalize */
     if (!is_zero)
@@ -465,36 +479,25 @@ std::istream& operator>>(std::istream &in, bn128_G1 &g)
     {
         g = bn128_G1::zero();
     }
-
-    return in;
 }
 
-std::ostream& operator<<(std::ostream& out, const std::vector<bn128_G1> &v)
+std::ostream& operator<<(std::ostream &out, const bn128_G1 &g)
 {
-    out << v.size() << "\n";
-    for (const bn128_G1& t : v)
-    {
-        out << t << OUTPUT_NEWLINE;
-    }
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
     return out;
 }
 
-std::istream& operator>>(std::istream& in, std::vector<bn128_G1> &v)
+std::istream& operator>>(std::istream &in, bn128_G1 &g)
 {
-    v.clear();
-
-    size_t s;
-    in >> s;
-    consume_newline(in);
-    v.reserve(s);
-
-    for (size_t i = 0; i < s; ++i)
-    {
-        bn128_G1 g;
-        in >> g;
-        consume_OUTPUT_NEWLINE(in);
-        v.emplace_back(g);
-    }
+#ifdef NO_PT_COMPRESSION
+    bn128_G1::read_uncompressed(in, g);
+#else
+    bn128_G1::read_compressed(in, g);
+#endif
     return in;
 }
 

--- a/libff/algebra/curves/bn128/bn128_g1.hpp
+++ b/libff/algebra/curves/bn128/bn128_g1.hpp
@@ -72,8 +72,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const bn128_G1 &g);
-    friend std::istream& operator>>(std::istream &in, bn128_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, bn128_G1 &);
+    static void read_compressed(std::istream &, bn128_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<bn128_G1> &vec);
 };
@@ -89,10 +91,6 @@ bn128_G1 operator*(const Fp_model<m,modulus_p> &lhs, const bn128_G1 &rhs)
 {
     return scalar_mul<bn128_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<bn128_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<bn128_G1> &v);
-
 
 } // libff
 #endif // BN128_G1_HPP_

--- a/libff/algebra/curves/bn128/bn128_g2.cpp
+++ b/libff/algebra/curves/bn128/bn128_g2.cpp
@@ -379,14 +379,13 @@ bn128_G2 bn128_G2::random_element()
     return bn128_Fr::random_element().as_bigint() * G2_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const bn128_G2 &g)
+void bn128_G2::write_uncompressed(std::ostream &out) const
 {
-    bn128_G2 gcopy(g);
+    bn128_G2 gcopy(*this);
     gcopy.to_affine_coordinates();
 
     out << (gcopy.is_zero() ? '1' : '0') << OUTPUT_SEPARATOR;
 
-#ifdef NO_PT_COMPRESSION
     /* no point compression case */
 #ifndef BINARY_OUTPUT
     out << gcopy.X.a_ << OUTPUT_SEPARATOR << gcopy.X.b_ << OUTPUT_SEPARATOR;
@@ -397,9 +396,15 @@ std::ostream& operator<<(std::ostream &out, const bn128_G2 &g)
     out.write((char*) &gcopy.Y.a_, sizeof(gcopy.Y.a_));
     out.write((char*) &gcopy.Y.b_, sizeof(gcopy.Y.b_));
 #endif
+}
 
-#else
-    /* point compression case */
+void bn128_G2::write_compressed(std::ostream &out) const
+{
+    bn128_G2 gcopy(*this);
+    gcopy.to_affine_coordinates();
+
+    out << (gcopy.is_zero() ? '1' : '0') << OUTPUT_SEPARATOR;
+
 #ifndef BINARY_OUTPUT
     out << gcopy.X.a_ << OUTPUT_SEPARATOR << gcopy.X.b_;
 #else
@@ -407,20 +412,15 @@ std::ostream& operator<<(std::ostream &out, const bn128_G2 &g)
     out.write((char*) &gcopy.X.b_, sizeof(gcopy.X.b_));
 #endif
     out << OUTPUT_SEPARATOR << (((unsigned char*)&gcopy.Y.a_)[0] & 1 ? '1' : '0');
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, bn128_G2 &g)
+void bn128_G2::read_uncompressed(std::istream &in, bn128_G2 &g)
 {
     char is_zero;
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
 
-#ifdef NO_PT_COMPRESSION
-    /* no point compression case */
 #ifndef BINARY_OUTPUT
     in >> g.X.a_;
     consume_OUTPUT_SEPARATOR(in);
@@ -436,8 +436,24 @@ std::istream& operator>>(std::istream &in, bn128_G2 &g)
     in.read((char*) &g.Y.b_, sizeof(g.Y.b_));
 #endif
 
-#else
-    /* point compression case */
+    /* finalize */
+    if (!is_zero)
+    {
+        g.Z = bn::Fp2(bn::Fp(1), bn::Fp(0));
+    }
+    else
+    {
+        g = bn128_G2::zero();
+    }
+}
+
+void bn128_G2::read_compressed(std::istream &in, bn128_G2 &g)
+{
+    char is_zero;
+    in.read((char*)&is_zero, 1); // this reads is_zero;
+    is_zero -= '0';
+    consume_OUTPUT_SEPARATOR(in);
+
     bn::Fp2 tX;
 #ifndef BINARY_OUTPUT
     in >> tX.a_;
@@ -467,7 +483,6 @@ std::istream& operator>>(std::istream &in, bn128_G2 &g)
             bn::Fp2::neg(g.Y, g.Y);
         }
     }
-#endif
 
     /* finalize */
     if (!is_zero)
@@ -478,7 +493,25 @@ std::istream& operator>>(std::istream &in, bn128_G2 &g)
     {
         g = bn128_G2::zero();
     }
+}
 
+std::ostream& operator<<(std::ostream &out, const bn128_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, bn128_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    bn128_G2::read_uncompressed(in, g);
+#else
+    bn128_G2::read_compressed(in, g);
+#endif
     return in;
 }
 

--- a/libff/algebra/curves/bn128/bn128_g2.hpp
+++ b/libff/algebra/curves/bn128/bn128_g2.hpp
@@ -73,8 +73,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const bn128_G2 &g);
-    friend std::istream& operator>>(std::istream &in, bn128_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, bn128_G2 &);
+    static void read_compressed(std::istream &, bn128_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<bn128_G2> &vec);
 };

--- a/libff/algebra/curves/edwards/edwards_g1.cpp
+++ b/libff/algebra/curves/edwards/edwards_g1.cpp
@@ -300,33 +300,44 @@ edwards_G1 edwards_G1::random_element()
     return edwards_Fr::random_element().as_bigint() * G1_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const edwards_G1 &g)
+void edwards_G1::write_uncompressed(std::ostream &out) const
 {
-    edwards_G1 copy(g);
+    edwards_G1 copy(*this);
     copy.to_affine_coordinates();
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, edwards_G1 &g)
+void edwards_G1::write_compressed(std::ostream &out) const
+{
+    edwards_G1 copy(*this);
+    copy.to_affine_coordinates();
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
+}
+
+void edwards_G1::read_uncompressed(std::istream &in, edwards_G1 &g)
 {
     edwards_Fq tX, tY;
-
-#ifdef NO_PT_COMPRESSION
     in >> tX;
     consume_OUTPUT_SEPARATOR(in);
     in >> tY;
-#else
+
+    // using inverted coordinates
+    g.X = tY;
+    g.Y = tX;
+    g.Z = tX * tY;
+
+#ifdef USE_MIXED_ADDITION
+    g.to_special();
+#endif
+}
+
+void edwards_G1::read_compressed(std::istream &in, edwards_G1 &g)
+{
     /*
       a x^2 + y^2 = 1 + d x^2 y^2
       y = sqrt((1-ax^2)/(1-dx^2))
     */
+    edwards_Fq tX, tY;
     unsigned char Y_lsb;
     in >> tX;
 
@@ -343,7 +354,6 @@ std::istream& operator>>(std::istream &in, edwards_G1 &g)
     {
         tY = -tY;
     }
-#endif
 
     // using inverted coordinates
     g.X = tY;
@@ -353,38 +363,25 @@ std::istream& operator>>(std::istream &in, edwards_G1 &g)
 #ifdef USE_MIXED_ADDITION
     g.to_special();
 #endif
-
-    return in;
 }
 
-std::ostream& operator<<(std::ostream& out, const std::vector<edwards_G1> &v)
+std::ostream& operator<<(std::ostream &out, const edwards_G1 &g)
 {
-    out << v.size() << "\n";
-    for (const edwards_G1& t : v)
-    {
-        out << t << OUTPUT_NEWLINE;
-    }
-
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
     return out;
 }
 
-std::istream& operator>>(std::istream& in, std::vector<edwards_G1> &v)
+std::istream& operator>>(std::istream &in, edwards_G1 &g)
 {
-    v.clear();
-
-    size_t s;
-    in >> s;
-    v.reserve(s);
-    consume_newline(in);
-
-    for (size_t i = 0; i < s; ++i)
-    {
-        edwards_G1 g;
-        in >> g;
-        v.emplace_back(g);
-        consume_OUTPUT_NEWLINE(in);
-    }
-
+#ifdef NO_PT_COMPRESSION
+    edwards_G1::read_uncompressed(in, g);
+#else
+    edwards_G1::read_compressed(in, g);
+#endif
     return in;
 }
 

--- a/libff/algebra/curves/edwards/edwards_g1.hpp
+++ b/libff/algebra/curves/edwards/edwards_g1.hpp
@@ -70,8 +70,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const edwards_G1 &g);
-    friend std::istream& operator>>(std::istream &in, edwards_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, edwards_G1 &);
+    static void read_compressed(std::istream &, edwards_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<edwards_G1> &vec);
 };
@@ -87,9 +89,6 @@ edwards_G1 operator*(const Fp_model<m,modulus_p> &lhs, const edwards_G1 &rhs)
 {
     return scalar_mul<edwards_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<edwards_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<edwards_G1> &v);
 
 } // libff
 #endif // EDWARDS_G1_HPP_

--- a/libff/algebra/curves/edwards/edwards_g2.cpp
+++ b/libff/algebra/curves/edwards/edwards_g2.cpp
@@ -332,32 +332,45 @@ edwards_G2 edwards_G2::random_element()
     return edwards_Fr::random_element().as_bigint() * G2_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const edwards_G2 &g)
+void edwards_G2::write_uncompressed(std::ostream &out) const
 {
-    edwards_G2 copy(g);
+    edwards_G2 copy(*this);
     copy.to_affine_coordinates();
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
-#endif
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, edwards_G2 &g)
+void edwards_G2::write_compressed(std::ostream &out) const
+{
+    edwards_G2 copy(*this);
+    copy.to_affine_coordinates();
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
+}
+
+void edwards_G2::read_uncompressed(std::istream &in, edwards_G2 &g)
 {
     edwards_Fq3 tX, tY;
-
-#ifdef NO_PT_COMPRESSION
     in >> tX;
     consume_OUTPUT_SEPARATOR(in);
     in >> tY;
-#else
+
+    // using inverted coordinates
+    g.X = tY;
+    g.Y = tX;
+    g.Z = tX * tY;
+
+#ifdef USE_MIXED_ADDITION
+    g.to_special();
+#endif
+}
+
+void edwards_G2::read_compressed(std::istream &in, edwards_G2 &g)
+{
     /*
       a x^2 + y^2 = 1 + d x^2 y^2
       y = sqrt((1-ax^2)/(1-dx^2))
     */
+    edwards_Fq3 tX, tY;
     unsigned char Y_lsb;
     in >> tX;
     consume_OUTPUT_SEPARATOR(in);
@@ -375,7 +388,6 @@ std::istream& operator>>(std::istream &in, edwards_G2 &g)
     {
         tY = -tY;
     }
-#endif
 
     // using inverted coordinates
     g.X = tY;
@@ -385,7 +397,25 @@ std::istream& operator>>(std::istream &in, edwards_G2 &g)
 #ifdef USE_MIXED_ADDITION
     g.to_special();
 #endif
+}
 
+std::ostream& operator<<(std::ostream &out, const edwards_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, edwards_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    edwards_G2::read_uncompressed(in, g);
+#else
+    edwards_G2::read_compressed(in, g);
+#endif
     return in;
 }
 

--- a/libff/algebra/curves/edwards/edwards_g2.hpp
+++ b/libff/algebra/curves/edwards/edwards_g2.hpp
@@ -76,8 +76,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const edwards_G2 &g);
-    friend std::istream& operator>>(std::istream &in, edwards_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, edwards_G2 &);
+    static void read_compressed(std::istream &, edwards_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<edwards_G2> &vec);
 };

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g1.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g1.cpp
@@ -386,31 +386,49 @@ mnt4_G1 mnt4_G1::random_element()
     return (scalar_field::random_element().as_bigint()) * G1_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const mnt4_G1 &g)
+void mnt4_G1::write_uncompressed(std::ostream &out) const
 {
-    mnt4_G1 copy(g);
+    mnt4_G1 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, mnt4_G1 &g)
+void mnt4_G1::write_compressed(std::ostream &out) const
+{
+    mnt4_G1 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
+}
+
+void mnt4_G1::read_uncompressed(std::istream &in, mnt4_G1 &g)
 {
     char is_zero;
     mnt4_Fq tX, tY;
-
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using projective coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt4_Fq::one();
+    }
+    else
+    {
+        g = mnt4_G1::zero();
+    }
+}
+
+void mnt4_G1::read_compressed(std::istream &in, mnt4_G1 &g)
+{
+    char is_zero;
+    mnt4_Fq tX, tY;
     in.read((char*)&is_zero, 1);
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -433,7 +451,7 @@ std::istream& operator>>(std::istream &in, mnt4_G1 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using projective coordinates
     if (!is_zero)
     {
@@ -445,40 +463,25 @@ std::istream& operator>>(std::istream &in, mnt4_G1 &g)
     {
         g = mnt4_G1::zero();
     }
-
-    return in;
 }
 
-std::ostream& operator<<(std::ostream& out, const std::vector<mnt4_G1> &v)
+std::ostream& operator<<(std::ostream &out, const mnt4_G1 &g)
 {
-    out << v.size() << "\n";
-    for (const mnt4_G1& t : v)
-    {
-        out << t << OUTPUT_NEWLINE;
-    }
-
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
     return out;
 }
 
-std::istream& operator>>(std::istream& in, std::vector<mnt4_G1> &v)
+std::istream& operator>>(std::istream &in, mnt4_G1 &g)
 {
-    v.clear();
-
-    size_t s;
-    in >> s;
-
-    consume_newline(in);
-
-    v.reserve(s);
-
-    for (size_t i = 0; i < s; ++i)
-    {
-        mnt4_G1 g;
-        in >> g;
-        consume_OUTPUT_NEWLINE(in);
-        v.emplace_back(g);
-    }
-
+#ifdef NO_PT_COMPRESSION
+    mnt4_G1::read_uncompressed(in, g);
+#else
+    mnt4_G1::read_compressed(in, g);
+#endif
     return in;
 }
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g1.hpp
@@ -76,8 +76,10 @@ public:
     static bigint<mnt4_Fq::num_limbs> base_field_char() { return mnt4_Fq::field_char(); }
     static bigint<mnt4_Fr::num_limbs> order() { return mnt4_Fr::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt4_G1 &g);
-    friend std::istream& operator>>(std::istream &in, mnt4_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt4_G1 &);
+    static void read_compressed(std::istream &, mnt4_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt4_G1> &vec);
 };
@@ -93,9 +95,6 @@ mnt4_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt4_G1 &rhs)
 {
     return scalar_mul<mnt4_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<mnt4_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<mnt4_G1> &v);
 
 } // libff
 

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.cpp
@@ -410,31 +410,49 @@ mnt4_G2 mnt4_G2::random_element()
     return (mnt4_Fr::random_element().as_bigint()) * G2_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g)
+void mnt4_G2::write_uncompressed(std::ostream &out) const
 {
-    mnt4_G2 copy(g);
+    mnt4_G2 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, mnt4_G2 &g)
+void mnt4_G2::write_compressed(std::ostream &out) const
+{
+    mnt4_G2 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
+}
+
+void mnt4_G2::read_uncompressed(std::istream &in, mnt4_G2 &g)
 {
     char is_zero;
     mnt4_Fq2 tX, tY;
-
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using projective coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt4_Fq2::one();
+    }
+    else
+    {
+        g = mnt4_G2::zero();
+    }
+}
+
+void mnt4_G2::read_compressed(std::istream &in, mnt4_G2 &g)
+{
+    char is_zero;
+    mnt4_Fq2 tX, tY;
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -457,7 +475,7 @@ std::istream& operator>>(std::istream &in, mnt4_G2 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using projective coordinates
     if (!is_zero)
     {
@@ -469,8 +487,6 @@ std::istream& operator>>(std::istream &in, mnt4_G2 &g)
     {
         g = mnt4_G2::zero();
     }
-
-    return in;
 }
 
 void mnt4_G2::batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec)
@@ -490,6 +506,26 @@ void mnt4_G2::batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec)
     {
         vec[i] = mnt4_G2(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
+}
+
+std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, mnt4_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    mnt4_G2::read_uncompressed(in, g);
+#else
+    mnt4_G2::read_compressed(in, g);
+#endif
+    return in;
 }
 
 } // libff

--- a/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_g2.hpp
@@ -81,8 +81,10 @@ public:
     static bigint<mnt4_Fq::num_limbs> base_field_char() { return mnt4_Fq::field_char(); }
     static bigint<mnt4_Fr::num_limbs> order() { return mnt4_Fr::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt4_G2 &g);
-    friend std::istream& operator>>(std::istream &in, mnt4_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt4_G2 &);
+    static void read_compressed(std::istream &, mnt4_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt4_G2> &vec);
 };

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.cpp
@@ -386,31 +386,49 @@ mnt6_G1 mnt6_G1::random_element()
     return (scalar_field::random_element().as_bigint()) * G1_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g)
+void mnt6_G1::write_uncompressed(std::ostream &out) const
 {
-    mnt6_G1 copy(g);
+    mnt6_G1 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, mnt6_G1 &g)
+void mnt6_G1::write_compressed(std::ostream &out) const
+{
+    mnt6_G1 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.as_bigint().data[0] & 1);
+}
+
+void mnt6_G1::read_uncompressed(std::istream &in, mnt6_G1 &g)
 {
     char is_zero;
     mnt6_Fq tX, tY;
-
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using projective coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt6_Fq::one();
+    }
+    else
+    {
+        g = mnt6_G1::zero();
+    }
+}
+
+void mnt6_G1::read_compressed(std::istream &in, mnt6_G1 &g)
+{
+    char is_zero;
+    mnt6_Fq tX, tY;
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -433,7 +451,7 @@ std::istream& operator>>(std::istream &in, mnt6_G1 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using projective coordinates
     if (!is_zero)
     {
@@ -445,40 +463,6 @@ std::istream& operator>>(std::istream &in, mnt6_G1 &g)
     {
         g = mnt6_G1::zero();
     }
-
-    return in;
-}
-
-std::ostream& operator<<(std::ostream& out, const std::vector<mnt6_G1> &v)
-{
-    out << v.size() << "\n";
-    for (const mnt6_G1& t : v)
-    {
-        out << t << OUTPUT_NEWLINE;
-    }
-
-    return out;
-}
-
-std::istream& operator>>(std::istream& in, std::vector<mnt6_G1> &v)
-{
-    v.clear();
-
-    size_t s;
-    in >> s;
-    consume_newline(in);
-
-    v.reserve(s);
-
-    for (size_t i = 0; i < s; ++i)
-    {
-        mnt6_G1 g;
-        in >> g;
-        consume_OUTPUT_NEWLINE(in);
-        v.emplace_back(g);
-    }
-
-    return in;
 }
 
 void mnt6_G1::batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec)
@@ -498,6 +482,26 @@ void mnt6_G1::batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec)
     {
         vec[i] = mnt6_G1(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
+}
+
+std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, mnt6_G1 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    mnt6_G1::read_uncompressed(in, g);
+#else
+    mnt6_G1::read_compressed(in, g);
+#endif
+    return in;
 }
 
 } // libff

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g1.hpp
@@ -76,8 +76,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt6_G1 &g);
-    friend std::istream& operator>>(std::istream &in, mnt6_G1 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt6_G1 &);
+    static void read_compressed(std::istream &, mnt6_G1 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt6_G1> &vec);
 };
@@ -93,9 +95,6 @@ mnt6_G1 operator*(const Fp_model<m,modulus_p> &lhs, const mnt6_G1 &rhs)
 {
     return scalar_mul<mnt6_G1, m>(rhs, lhs.as_bigint());
 }
-
-std::ostream& operator<<(std::ostream& out, const std::vector<mnt6_G1> &v);
-std::istream& operator>>(std::istream& in, std::vector<mnt6_G1> &v);
 
 } // libff
 

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.cpp
@@ -417,31 +417,51 @@ mnt6_G2 mnt6_G2::random_element()
     return (mnt6_Fr::random_element().as_bigint()) * G2_one;
 }
 
-std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g)
+void mnt6_G2::write_uncompressed(std::ostream &out) const
 {
-    mnt6_G2 copy(g);
+    mnt6_G2 copy(*this);
     copy.to_affine_coordinates();
 
     out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
-#ifdef NO_PT_COMPRESSION
     out << copy.X << OUTPUT_SEPARATOR << copy.Y;
-#else
-    /* storing LSB of Y */
-    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
-#endif
-
-    return out;
 }
 
-std::istream& operator>>(std::istream &in, mnt6_G2 &g)
+void mnt6_G2::write_compressed(std::ostream &out) const
+{
+    mnt6_G2 copy(*this);
+    copy.to_affine_coordinates();
+
+    out << (copy.is_zero() ? 1 : 0) << OUTPUT_SEPARATOR;
+    /* storing LSB of Y */
+    out << copy.X << OUTPUT_SEPARATOR << (copy.Y.c0.as_bigint().data[0] & 1);
+}
+
+void mnt6_G2::read_uncompressed(std::istream &in, mnt6_G2 &g)
 {
     char is_zero;
     mnt6_Fq3 tX, tY;
 
-#ifdef NO_PT_COMPRESSION
     in >> is_zero >> tX >> tY;
     is_zero -= '0';
-#else
+
+    // using projective coordinates
+    if (!is_zero)
+    {
+        g.X = tX;
+        g.Y = tY;
+        g.Z = mnt6_Fq3::one();
+    }
+    else
+    {
+        g = mnt6_G2::zero();
+    }
+}
+
+void mnt6_G2::read_compressed(std::istream &in, mnt6_G2 &g)
+{
+    char is_zero;
+    mnt6_Fq3 tX, tY;
+
     in.read((char*)&is_zero, 1); // this reads is_zero;
     is_zero -= '0';
     consume_OUTPUT_SEPARATOR(in);
@@ -464,7 +484,7 @@ std::istream& operator>>(std::istream &in, mnt6_G2 &g)
             tY = -tY;
         }
     }
-#endif
+
     // using projective coordinates
     if (!is_zero)
     {
@@ -476,8 +496,6 @@ std::istream& operator>>(std::istream &in, mnt6_G2 &g)
     {
         g = mnt6_G2::zero();
     }
-
-    return in;
 }
 
 void mnt6_G2::batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec)
@@ -497,6 +515,26 @@ void mnt6_G2::batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec)
     {
         vec[i] = mnt6_G2(vec[i].X * Z_vec[i], vec[i].Y * Z_vec[i], one);
     }
+}
+
+std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    g.write_uncompressed(out);
+#else
+    g.write_compressed(out);
+#endif
+    return out;
+}
+
+std::istream& operator>>(std::istream &in, mnt6_G2 &g)
+{
+#ifdef NO_PT_COMPRESSION
+    mnt6_G2::read_uncompressed(in, g);
+#else
+    mnt6_G2::read_compressed(in, g);
+#endif
+    return in;
 }
 
 } // libff

--- a/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_g2.hpp
@@ -81,8 +81,10 @@ public:
     static bigint<base_field::num_limbs> base_field_char() { return base_field::field_char(); }
     static bigint<scalar_field::num_limbs> order() { return scalar_field::field_char(); }
 
-    friend std::ostream& operator<<(std::ostream &out, const mnt6_G2 &g);
-    friend std::istream& operator>>(std::istream &in, mnt6_G2 &g);
+    void write_uncompressed(std::ostream &) const;
+    void write_compressed(std::ostream &) const;
+    static void read_uncompressed(std::istream &, mnt6_G2 &);
+    static void read_compressed(std::istream &, mnt6_G2 &);
 
     static void batch_to_special_all_non_zeros(std::vector<mnt6_G2> &vec);
 };

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -136,9 +136,19 @@ void test_output()
     {
         std::stringstream ss;
         ss << g;
+        g.write_compressed(ss);
+        g.write_uncompressed(ss);
+
         GroupT gg;
+        GroupT gg_comp;
+        GroupT gg_uncomp;
         ss >> gg;
+        GroupT::read_compressed(ss, gg_comp);
+        GroupT::read_uncompressed(ss, gg_uncomp);
+
         assert(g == gg);
+        assert(g == gg_comp);
+        assert(g == gg_uncomp);
         /* use a random point in next iteration */
         g = GroupT::random_element();
     }


### PR DESCRIPTION
Expose both compressed and uncompressed serialization (instead of fixing it based on the cmake config).  Adds `{read,write}_[un]compressed` methods to G1 and G2 on all pairings.

This PR shows up a lot of code that could be shared between implementations. In a separate PR this can be addressed with the parameterized base-class technique: `class edwards_G1 : public G1_base<edwards_G1>`.