### PR TITLE
Faster membership check for BLS12-377

### DIFF
--- a/libff/CMakeLists.txt
+++ b/libff/CMakeLists.txt
@@ -137,5 +137,18 @@ if ("${IS_LIBFF_PARENT}")
     ff
   )
 
-  add_dependencies(profile multiexp_profile)
+  add_executable(
+    algebra_groups_profile
+    EXCLUDE_FROM_ALL
+
+    algebra/curves/profile/algebra_groups_profile.cpp
+  )
+  target_link_libraries(algebra_groups_profile ff)
+
+  add_dependencies(
+    profile
+
+    multiexp_profile
+    algebra_groups_profile
+  )
 endif()

--- a/libff/algebra/curves/bls12_377/bls12_377.sage
+++ b/libff/algebra/curves/bls12_377/bls12_377.sage
@@ -70,7 +70,7 @@ def g1_fast_subgroup_check_coefficients(g1_order, q, r):
         lambdas = _find_lambda_n(Fn)
         for l in lambdas:
             if 0 == Fn(c0 + c1 * l):
-                raise Exception(f"elements order {n} may be mapped to 0")
+                raise Exception(f"elements of order {n} may be mapped to 0")
 
     def _check_lambdas_not_root_in_subgroups(group_order, q, r, c0, c1):
         """
@@ -78,34 +78,14 @@ def g1_fast_subgroup_check_coefficients(g1_order, q, r):
         [c0]P + [c1]sigma(P) does not kill the n-torsion.
         """
 
-        def _no_element_order_4():
-            """
-            E(Fq) contains no elements of order 4 (and hence of order 2^m, m > 1).
-              E: y^2 - x^3 - 1
-              Any order 2 element has dE/dy == 0, i.e. y == 0.
-              Any order 4 element P must thereby have:
-                (P + P) = R
-                Ry == 0
-              By group laws:
-                21 * Px^6 - 5 * Px^3 + 2 == 0
-            """
-            Fq = GF(q)
-            Fqp.<x> = PolynomialRing(Fq)
-            f = 21 * x^6 - 5 * x^3 + 2
-            if len(f.roots()):
-                raise Exception(f"E(Fq) may contain elements of order 4")
-        _no_element_order_4()
-
-        # For other prime power factors n, show that no lambda_n cannot be a root of:
-        #   c0 + c1*x mod n
+        # For each n = prime^power factors of group_order, show that no
+        # lambda_n is a root of:
+        #   c0 + c1*x (mod n)
         for (prime, power) in factor(group_order):
             # print(f"  group_order has factor (p={prime}, pow={power})")
             if prime == r:
                 # print("   skipping")
                 continue
-            if prime == 2:
-                # No need to check powers greater than 1
-                power = 1
 
             for p in range(1, power+1):
                 n = prime^p

--- a/libff/algebra/curves/bls12_377/bls12_377.sage
+++ b/libff/algebra/curves/bls12_377/bls12_377.sage
@@ -1,4 +1,4 @@
-#!/usr/bin/env sage -python
+#!/usr/bin/env sage -python3
 
 from sage.all import *
 import sys
@@ -17,6 +17,9 @@ def q(x):
 def g1_h(x):
     return ((x - 1)^2) // 3
 
+def g1_t(x):
+    return (x + 1)
+
 # Compute G2 cofactor
 # See: Proposition 2, Section 3.4: https://eprint.iacr.org/2015/247.pdf
 def g2_h(x):
@@ -30,6 +33,174 @@ def g1_order(curve_order):
     biggest_factor = decomposition[-1]
     assert(biggest_factor[1] == 1)
     return biggest_factor[0]
+
+
+def g1_fast_subgroup_check_coefficients(g1_order, q, r):
+    """
+    Find \beta Fq with multiplicative order 3. For each element (x,y) in G1
+    with n = order or (x, y), the endomorphism \sigma(x, y) -> (\beta x, y) is
+    equivalent to [\lambda_n], where \lambda_n is a root of x^2 + x + 1 in Fn.
+
+    Find c0 and c1 s.t. c0 + c1 * \lambda_r = r
+    (i.e. [c0]P + [c1]\sigma(P) = [r]P for P in r-torsion)
+
+    Ensure that c0 + c1 * x has no roots mod any other subgroup order
+    (i.e. [c0]P + [c1]\sigma(P) does not kill members of any other torsion).
+
+    In this case, [c0]P + [c1]\sigma(P) == 0 is a fast r-torsion membership
+    check for elements of E(Fq).
+    """
+
+    print(f" [r1_0]P + [r2_1]\sigma(P) == 0")
+
+    def _find_lambda_n(Fn):
+        """
+        Return solutions of \lambda^2 + \lambda + 1 = 0 mod n
+        """
+        Fny.<y> = PolynomialRing(Fn)
+        lambda_r_poly = y^2 + y + 1
+        lambda_r_poly_roots = lambda_r_poly.roots()
+        return [root[0] for root in lambda_r_poly_roots]
+
+    def _check_lambdas_not_root_in_subgroup_size(n, c0, c1):
+        """
+        Check that no possible values of lambda_n are roots of c0 + c1*x in GF(n)
+        """
+        Fn = GF(n)
+        lambdas = _find_lambda_n(Fn)
+        for l in lambdas:
+            if 0 == Fn(c0 + c1 * l):
+                raise Exception(f"elements order {n} may be mapped to 0")
+
+    def _check_lambdas_not_root_in_subgroups(group_order, q, r, c0, c1):
+        """
+        For each prime-power factor n of group_order, perform the check that
+        [c0]P + [c1]sigma(P) does not kill the n-torsion.
+        """
+
+        def _no_element_order_4():
+            """
+            E(Fq) contains no elements of order 4 (and hence of order 2^m, m > 1).
+              E: y^2 - x^3 - 1
+              Any order 2 element has dE/dy == 0, i.e. y == 0.
+              Any order 4 element P must thereby have:
+                (P + P) = R
+                Ry == 0
+              By group laws:
+                21 * Px^6 - 5 * Px^3 + 2 == 0
+            """
+            Fq = GF(q)
+            Fqp.<x> = PolynomialRing(Fq)
+            f = 21 * x^6 - 5 * x^3 + 2
+            if len(f.roots()):
+                raise Exception(f"E(Fq) may contain elements of order 4")
+        _no_element_order_4()
+
+        # For other prime power factors n, show that no lambda_n cannot be a root of:
+        #   c0 + c1*x mod n
+        for (prime, power) in factor(group_order):
+            # print(f"  group_order has factor (p={prime}, pow={power})")
+            if prime == r:
+                # print("   skipping")
+                continue
+            if prime == 2:
+                # No need to check powers greater than 1
+                power = 1
+
+            for p in range(1, power+1):
+                n = prime^p
+                # print(f"   p={p}, n={n}")
+                _check_lambdas_not_root_in_subgroup_size(n, c0, c1)
+
+    # Find an element of Fq with multiplicative order 3
+    beta = min(_find_lambda_n(GF(q)))
+    print(f" beta: {beta}  [in sigma(x,y) = (beta * x, y)]")
+
+    # lambda for the r-torsion
+    lambda_r_poly_roots = _find_lambda_n(GF(r));
+    # print(f" lambda_r_poly_roots: {lambda_r_poly_roots}")
+    lambda_r = min(lambda_r_poly_roots) # [root[0] for root in lambda_r_poly_roots])
+    print(f" (lambda_r: {lambda_r})")
+
+    # Find r1_0, r1_1 s.t. r = r1_0 + r1_1*lambda_r
+    r1_1 = int(int(r) // int(lambda_r))
+    r1_0 = int(r % r1_1)
+    _check_lambdas_not_root_in_subgroups(g1_order, q, r, r1_0, r1_1)
+
+    return r1_0, r1_1
+
+
+def fuentes_g2_fast_cofactor_coefficients(x):
+    """
+    See Section 4.1: https://eprint.iacr.org/2017/419.pdf
+      [m * h2]P = [x^2 - x - 1]P + [x - 1]ψ(P) + ψ^2(2P)
+    where:
+      m = 3x^3 - 3
+    """
+    x_2 = x * x
+    c0 = x_2 - x - 1
+    c1 = x - 1
+    print(f" m = {3*(x_2*x - 1)}")
+    return c0, c1
+
+
+def g2_fast_cofactor_coefficients(curve_order, q, h2):
+    """
+    Compute faster cofactor multiplication coefficients:
+    See Section 3.1: https://eprint.iacr.org/2017/419.pdf
+
+    Multiplication by 3*h2 of P in E'/F_{q^2} can be reduced to:
+      [x^3−x^2−x+4]P+ [x^3−x^2−x+1]ψ(P) + [−x^2+2x−1]ψ^2(P)
+    """
+
+    # For P in E'(Fq2),
+    #   [q]P = [t]ψ(P) - ψ^2(P)
+    # We seek
+    #   h2_0 and h2_1 s.t. h2 = h2_0 + h2_1 * q mod #E'(Fp2)
+    # so that:
+    #   [h]P = [h_0]P + [h_1]([t]ψ(P) - ψ^2(P))
+    print(f" [h]P = [h2_0]P + [h2_1]([t]ψ(P) - ψ^2(P))")
+
+    # Section 3.1: https://eprint.iacr.org/2017/419.pdf:
+    #   x_2 = x*x
+    #   x_3 = x * x_2
+    #   c0 = x_3 - x_2 - x + 4
+    #   c1 = x_3 - x_2 - x + 1
+    #   c2 = 2*x - x_2 - 1
+    #   return c0, c1, c2
+    # This trivial calculation reveals the same coefficients / 3 (resulting
+    # in slightly fewer operations)
+
+    h2_1 = int(floor(h2 / q))
+    h2_0 = h2 - (h2_1 * q)
+    return h2_0, h2_1
+
+
+def g2_fast_subgroup_check_coefficients(g2_order, q, r, t1, h2):
+    """
+    Compute coefficients of P, (ψ(P) - P) and ψ^2(P) to quickly multiply by
+    some factor k of r, s.t. gcd(k, curve_order/r) == 1. [kr] will kill the
+    r-torsion without killing any other components.
+    """
+    # For P in E'(Fq2), ψ satisfies:
+    #   [q1]P = [t1]ψ(P) - ψ^2(P)
+    # where ψ is the untwist-frobenius-twist endomorphism
+
+    # Trivial solution:
+    #   h1.r = n1 = q1 - t1 + 1
+    #   [h1.r] P = [t1]ψ(P) - ψ^2(P) - [t]P + P
+    #            = P + [t](ψ(P) - P) - ψ^2(P)
+    print(f" 0 == [r2_0]P + [r2_1](ψ(P) - P) + [r2_2]ψ^2(P)")
+    g1_order = q - t1 + 1
+    h1 = g1_order / r
+
+    # Assert that [r] will only kill the G2 component.
+    assert h2 % r != 0
+    # Assert that [h1] will not kill any element of G2.
+    assert 1 == gcd(h1, h2)
+
+    return 1, t1, -1
+
 
 def main():
     print("Generating parameters for BLS12-377")
@@ -56,6 +227,7 @@ def main():
 
     # E/Fq
     curve = EllipticCurve(Fq, [0, 1])
+    curve_order = curve.order()
 
     # Generate Fp2_model
     euler_fp2 = (prime_q**2 - 1)/2; print('euler = {}'.format(euler_fp2))
@@ -79,16 +251,19 @@ def main():
     t = 475404855284145089315325463221726483993816145966867441829193658311651761271425728823393990805904040047516478740222806302278755994777496288961383541476974255391881599499962735436887347234371823579436839914935817251
     s = 47
 
+    g1_t_frob = g1_t(param)
+    print(f"g1_t_frob = {g1_t_frob}")
+
     t_minus_1_over_2 = (t-1)/2
     print('t_minus_1_over_2 = {}'.format(t_minus_1_over_2))
 
     # Build the twist E'/Fq2
     # Fq2 is constructed as Fq[u]/(u^2 - beta)Fq[u], where beta = -5
-    non_residue = Fq(-5)
-    print('non_residue = {}'.format(non_residue))
+    fq_non_residue = Fq(-5)
+    print('fq_non_residue = {}'.format(fq_non_residue))
     Fqx.<j> = PolynomialRing(Fq, 'j')
-    assert(Fqx(j^2 + 5).is_irreducible())
-    Fq2.<u> = GF(prime_q^2, modulus=j^2 + 5)
+    assert(Fqx(j^2 - fq_non_residue).is_irreducible())
+    Fq2.<u> = GF(prime_q^2, modulus=j^2 - fq_non_residue)
 
     nqr = Fq2(u)
     assert(nqr^euler_fp2 == Fq2(-1))
@@ -99,43 +274,70 @@ def main():
     d_twist = EllipticCurve(Fq2, [0, (1 / u)])
     twist = 0
     if (m_twist.order() % prime_r) == 0:
-        print "Good twist is: M-type"
+        print("Good twist is: M-type")
         twist = m_twist
     elif (d_twist.order() % prime_r) == 0:
-        print "Good twist is: D-type"
+        print("Good twist is: D-type")
         twist = d_twist
     else:
         raise BaseException("Error. None of the proposed twists has order divisible by r")
 
-    frob_coeff_c1_1 = non_residue^((0/2)) # = 1
-    frob_coeff_c1_2 = non_residue^(((prime_q) - 1)/2)
+    frob_coeff_c1_1 = fq_non_residue^((0/2)) # = 1
+    frob_coeff_c1_2 = fq_non_residue^(((prime_q) - 1)/2)
 
-    curve_order = curve.order()
     twist_order = twist.order()
+    assert(g1_order(curve_order) == prime_r)
 
     # Cofactors
     h1 = g1_h(param)
     # Check that the cofactor formula is sound
-    assert(h1 == curve_order // g1_order(curve_order))
+    assert(h1 == curve_order // prime_r)
+    print(f"G1 order: {curve_order}")
     print('h1 = {}'.format(h1))
+    assert(curve_order == prime_q + 1 - g1_t_frob)
+
     h2 = g2_h(param)
     # Check that the cofactor formula is sound
-    assert(h2 == twist_order // g1_order(curve_order))
+    assert(h2 == twist_order // prime_r)
+    print(f"G2 twist order: {twist_order}")
     print('h2 = {}'.format(h2))
+
+    # G1 fast subgroup check coefficients
+    print("G1 fast subgroup check coefficients:")
+    r1_0, r1_1 = g1_fast_subgroup_check_coefficients(curve_order, prime_q, prime_r)
+    print(f" r1_0: {r1_0}")
+    print(f" r1_1: {r1_1} ({hex(r1_1)})")
+
+    # G2 fast cofactor multiplication coefficients
+    print(f"G2 fast mul_by_cofactor coefficients:")
+    h2_0, h2_1 = g2_fast_cofactor_coefficients(twist_order, prime_q, h2)
+    print(f" h2_0={h2_0}")
+    print(f" h2_1={h2_1}")
+
+    # h2_0, h2_1 = fuentes_g2_fast_cofactor_coefficients(param)
+    # print(f"[Fuentes] G2 fast mul_by_cofactor coefficients: h2_0={h2_0}, h2_1={h2_1}")
+
+    # G2 fast subgroup check coefficients
+    print("G2 fast subgroup check coefficients:")
+    r2_0, r2_1, r2_2 = g2_fast_subgroup_check_coefficients(twist_order, prime_q, prime_r, g1_t_frob, h2)
+    print(f" r2_0={r2_0}")
+    print(f" r2_1={r2_1}")
+    print(f" r2_2={r2_2}")
 
     # Build the full tower extension
     """
     # Fq6 is constructed as Fq2[v]/(v^3 - u)Fq2[v]
+    fq2_non_residue = Fq2(u)
     Fq2x.<l> = PolynomialRing(Fq2, 'l')
-    assert(Fq2x(l^3 - u).is_irreducible())
-    # Fq6.<v> = GF((prime_q^2)^3, modulus=l^3 - u)
-    non_residue = Fq6(v);
+    assert(Fq2x(l^3 - fq2_non_residue).is_irreducible())
+    # Fq6.<v> = GF((prime_q^2)^3, modulus=Fq2x(l^3 - fq2_non_residue))
+    fq6_non_residue = Fq6(v)
     print('non_residue = {}'.format(non_residue))
-    
+
     # Fq12 is constructed as Fq6[w]/(w^2 + v)F[w]
     Fq3x.<w> = PolynomialRing(Fq3, 'w')
-    assert(Fqx(w^2 + v).is_irreducible())
-    Fq12.<n> = GF(((prime_q^2)^3)^2, modulus=w^2 +
+    assert(Fqx(w^2 - v).is_irreducible())
+    Fq12.<n> = GF(((prime_q^2)^3)^2, modulus=w^2 -v
     """
 
 if __name__ == '__main__':

--- a/libff/algebra/curves/bls12_377/bls12_377.sage
+++ b/libff/algebra/curves/bls12_377/bls12_377.sage
@@ -130,6 +130,31 @@ def g1_fast_subgroup_check_coefficients(g1_order, q, r):
     return r1_0, r1_1
 
 
+def g1_subgroup_proof_coefficients(curve, r, h1):
+    """
+    We can prove that some P belongs to G1 by providing some P' in E(Fq) s.t. P
+    = [h1] P'. This requires extra computation upfront, but can be verifed with
+    a single scalar multiplication by h1.
+    """
+    print(" P' = [w]P + Y => [h1] P' = P")
+    print("     where Y \in E(Fq)\G, w s.t. w*h = 1 mod r and Y s.t. [h1]Y = 0")
+
+    # 1 = a*r + b+h1 => b * h1 = 1 mod r
+    g, a, b = xgcd(int(r), int(h1))
+    assert(g == 1)
+
+    # Compute Y
+    fq = curve.base_field()
+    Yy_squared = fq(3^3 + 1)
+    Yy = sqrt(Yy_squared)
+    Y = r * curve([3, Yy])
+    # Y not in G1, but [h1]Y == 0
+    assert(r * Y != 0)
+    assert(h1 * Y == 0)
+
+    return b, Y
+
+
 def fuentes_g2_fast_cofactor_coefficients(x):
     """
     See Section 4.1: https://eprint.iacr.org/2017/419.pdf
@@ -307,6 +332,12 @@ def main():
     r1_0, r1_1 = g1_fast_subgroup_check_coefficients(curve_order, prime_q, prime_r)
     print(f" r1_0: {r1_0}")
     print(f" r1_1: {r1_1} ({hex(r1_1)})")
+
+    # G1 subgroup proof coefficients
+    print("G1 subgroup proof coefficients:")
+    w1, Y = g1_subgroup_proof_coefficients(curve, prime_r, h1)
+    print(f"  w = {w1}")
+    print(f"  Y = {Y}")
 
     # G2 fast cofactor multiplication coefficients
     print(f"G2 fast mul_by_cofactor coefficients:")

--- a/libff/algebra/curves/bls12_377/bls12_377_g1.cpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g1.cpp
@@ -377,6 +377,14 @@ bls12_377_G1 bls12_377_G1::mul_by_cofactor() const
     return bls12_377_G1::h * (*this);
 }
 
+bls12_377_G1 bls12_377_G1::sigma() const
+{
+    bls12_377_G1 result = *this;
+    result.to_affine_coordinates();
+    result.X = bls12_377_g1_endomorphism_beta * result.X;
+    return result;
+}
+
 bool bls12_377_G1::is_well_formed() const
 {
     if (this->is_zero())
@@ -400,7 +408,14 @@ bool bls12_377_G1::is_well_formed() const
 
 bool bls12_377_G1::is_in_safe_subgroup() const
 {
-    return zero() == scalar_field::mod * (*this);
+    // Check that [c0]P + [c1]\sigma(P) == 0 (see bls12_377.sage), where:
+    //   c0: 1
+    //   c1: 91893752504881257701523279626832445441
+    //         (0x452217cc900000010a11800000000001)
+    const bls12_377_G1 sigma_g = sigma();
+    const bls12_377_G1 r_times_g =
+        bls12_377_g1_safe_subgroup_check_c1 * sigma_g + *this;
+    return zero() == r_times_g;
 }
 
 bls12_377_G1 bls12_377_G1::zero()

--- a/libff/algebra/curves/bls12_377/bls12_377_g1.cpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g1.cpp
@@ -418,6 +418,18 @@ bool bls12_377_G1::is_in_safe_subgroup() const
     return zero() == r_times_g;
 }
 
+bls12_377_G1 bls12_377_G1::proof_of_safe_subgroup() const
+{
+    // See bls12_377.sage.
+    //   w = 5285428838741532253824584287042945485047145357130994810877
+
+    return bls12_377_g1_proof_of_safe_subgroup_w * (*this) +
+        bls12_377_G1(
+            bls12_377_g1_proof_of_safe_subgroup_non_member_x,
+            bls12_377_g1_proof_of_safe_subgroup_non_member_y,
+            bls12_377_Fq::one());
+}
+
 bls12_377_G1 bls12_377_G1::zero()
 {
     return G1_zero;

--- a/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
@@ -65,9 +65,7 @@ public:
     bls12_377_G1 mixed_add(const bls12_377_G1 &other) const;
     bls12_377_G1 dbl() const;
 
-    // Multiply point by h, the cofactor, to eliminate the h-torsion components
-    // Note: Doing so isn't a silver bullet and may need to be be replaced by a
-    // proper subgroup membership test.
+    // Multiply point by h, the cofactor, to eliminate the h-torsion components.
     bls12_377_G1 mul_by_cofactor() const;
 
     bool is_well_formed() const;

--- a/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
@@ -68,6 +68,10 @@ public:
     // Multiply point by h, the cofactor, to eliminate the h-torsion components.
     bls12_377_G1 mul_by_cofactor() const;
 
+    // Endomorphism (x, y) -> (\beta * x, y) for \beta an element of Fq with
+    // order 3.
+    bls12_377_G1 sigma() const;
+
     bool is_well_formed() const;
     bool is_in_safe_subgroup() const;
 

--- a/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g1.hpp
@@ -75,6 +75,13 @@ public:
     bool is_well_formed() const;
     bool is_in_safe_subgroup() const;
 
+    // For P (this), return a point P' on the curve such that
+    // P'.mul_by_cofactor() == P. In some contexts, this is useful to show that
+    // P is in the safe subgroup G1, requiring only a small scalar
+    // multiplication by the verifier. Note that (in spite of the type) the
+    // point returned here is OUTSIDE of G1.
+    bls12_377_G1 proof_of_safe_subgroup() const;
+
     static bls12_377_G1 zero();
     static bls12_377_G1 one();
     static bls12_377_G1 random_element();

--- a/libff/algebra/curves/bls12_377/bls12_377_g2.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_g2.hpp
@@ -68,6 +68,7 @@ public:
     bls12_377_G2 mixed_add(const bls12_377_G2 &other) const;
     bls12_377_G2 dbl() const;
     bls12_377_G2 mul_by_q() const;
+    bls12_377_G2 untwist_frobenius_twist() const;
     bls12_377_G2 mul_by_cofactor() const;
 
     bool is_well_formed() const;

--- a/libff/algebra/curves/bls12_377/bls12_377_init.cpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_init.cpp
@@ -13,12 +13,28 @@ bigint<bls12_377_r_limbs> bls12_377_modulus_r;
 // bigint<bls12_377_q_limbs> bls12_377_modulus_q;
 
 bls12_377_Fq bls12_377_coeff_b;
+bigint<bls12_377_r_limbs> bls12_377_trace_of_frobenius;
 bls12_377_Fq2 bls12_377_twist;
 bls12_377_Fq2 bls12_377_twist_coeff_b;
 bls12_377_Fq bls12_377_twist_mul_by_b_c0;
 bls12_377_Fq bls12_377_twist_mul_by_b_c1;
 bls12_377_Fq2 bls12_377_twist_mul_by_q_X;
 bls12_377_Fq2 bls12_377_twist_mul_by_q_Y;
+
+// See bls12_377_G1::is_in_safe_subgroup
+bls12_377_Fq bls12_377_g1_endomorphism_beta;
+bigint<bls12_377_r_limbs> bls12_377_g1_safe_subgroup_check_c1;
+
+// Coefficients for G2 untwist-frobenius-twist
+bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_w;
+bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_v;
+bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_w_3;
+bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_v_inverse;
+bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_w_3_inverse;
+
+// Coefficients used in bls12_377_G2::mul_by_cofactor
+bigint<bls12_377_r_limbs> bls12_377_g2_mul_by_cofactor_h2_0;
+bigint<bls12_377_r_limbs> bls12_377_g2_mul_by_cofactor_h2_1;
 
 bigint<bls12_377_q_limbs> bls12_377_ate_loop_count;
 bool bls12_377_ate_is_loop_count_neg;
@@ -156,13 +172,20 @@ void init_bls12_377_params()
     // Identities
     bls12_377_G1::G1_zero = bls12_377_G1(bls12_377_Fq::zero(), bls12_377_Fq::one(), bls12_377_Fq::zero());
     bls12_377_G1::G1_one = bls12_377_G1(bls12_377_Fq("81937999373150964239938255573465948239988671502647976594219695644855304257327692006745978603320413799295628339695"), bls12_377_Fq("241266749859715473739788878240585681733927191168601896383759122102112907357779751001206799952863815012735208165030"), bls12_377_Fq::one());
-    
+
     // Curve coeffs
     bls12_377_G1::coeff_a = bls12_377_Fq::zero();
     bls12_377_G1::coeff_b = bls12_377_coeff_b;
 
+    // Trace of Frobenius
+    bls12_377_trace_of_frobenius = bigint_r("9586122913090633730");
+
     // Cofactor
     bls12_377_G1::h = bigint<bls12_377_G1::h_limbs>("30631250834960419227450344600217059328");
+
+    // G1 fast subgroup check:  0 == [c0]P + [c1]sigma(P)
+    bls12_377_g1_endomorphism_beta = bls12_377_Fq("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945");
+    bls12_377_g1_safe_subgroup_check_c1 = bigint_r("91893752504881257701523279626832445441");
 
     // WNAF
     //
@@ -230,13 +253,24 @@ void init_bls12_377_params()
     // Identities
     bls12_377_G2::G2_zero = bls12_377_G2(bls12_377_Fq2::zero(), bls12_377_Fq2::one(), bls12_377_Fq2::zero());
     bls12_377_G2::G2_one = bls12_377_G2(bls12_377_Fq2(bls12_377_Fq("111583945774695116443911226257823823434468740249883042837745151039122196680777376765707574547389190084887628324746"), bls12_377_Fq("129066980656703085518157301154335215886082112524378686555873161080604845924984124025594590925548060469686767592854")), bls12_377_Fq2(bls12_377_Fq("168863299724668977183029941347596462608978380503965103341003918678547611204475537878680436662916294540335494194722"), bls12_377_Fq("233892497287475762251335351893618429603672921469864392767514552093535653615809913098097380147379993375817193725968")), bls12_377_Fq2::one());
-    
+
     // Curve twist coeffs
     bls12_377_G2::coeff_a = bls12_377_Fq2::zero();
     bls12_377_G2::coeff_b = bls12_377_twist_coeff_b;
 
     // Cofactor
     bls12_377_G2::h = bigint<bls12_377_G2::h_limbs>("7923214915284317143930293550643874566881017850177945424769256759165301436616933228209277966774092486467289478618404761412630691835764674559376407658497");
+
+    // Untwist-Frobenius-Twist coefficients
+    bls12_377_Fq12 untwist_frobenius_twist_w = bls12_377_Fq12(bls12_377_Fq6::zero(), bls12_377_Fq6::one());
+    bls12_377_g2_untwist_frobenius_twist_v = untwist_frobenius_twist_w * untwist_frobenius_twist_w;
+    bls12_377_g2_untwist_frobenius_twist_w_3 = untwist_frobenius_twist_w * bls12_377_g2_untwist_frobenius_twist_v;
+    bls12_377_g2_untwist_frobenius_twist_v_inverse = bls12_377_g2_untwist_frobenius_twist_v.inverse();
+    bls12_377_g2_untwist_frobenius_twist_w_3_inverse = bls12_377_g2_untwist_frobenius_twist_w_3.inverse();
+
+    // Fast cofactor multiplication coefficients
+    bls12_377_g2_mul_by_cofactor_h2_0 = bigint_r("293634935485640680722085584138834120318524213360527933441");
+    bls12_377_g2_mul_by_cofactor_h2_1 = bigint_r("30631250834960419227450344600217059328");
 
     // G2 wNAF window table
     bls12_377_G2::wnaf_window_table.resize(0);

--- a/libff/algebra/curves/bls12_377/bls12_377_init.cpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_init.cpp
@@ -24,6 +24,9 @@ bls12_377_Fq2 bls12_377_twist_mul_by_q_Y;
 // See bls12_377_G1::is_in_safe_subgroup
 bls12_377_Fq bls12_377_g1_endomorphism_beta;
 bigint<bls12_377_r_limbs> bls12_377_g1_safe_subgroup_check_c1;
+bigint<bls12_377_r_limbs> bls12_377_g1_proof_of_safe_subgroup_w;
+bls12_377_Fq bls12_377_g1_proof_of_safe_subgroup_non_member_x;
+bls12_377_Fq bls12_377_g1_proof_of_safe_subgroup_non_member_y;
 
 // Coefficients for G2 untwist-frobenius-twist
 bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_w;
@@ -186,6 +189,13 @@ void init_bls12_377_params()
     // G1 fast subgroup check:  0 == [c0]P + [c1]sigma(P)
     bls12_377_g1_endomorphism_beta = bls12_377_Fq("80949648264912719408558363140637477264845294720710499478137287262712535938301461879813459410945");
     bls12_377_g1_safe_subgroup_check_c1 = bigint_r("91893752504881257701523279626832445441");
+
+    // G1 proof of subgroup: values used to generate x' s.t. [r]x' = x.
+    bls12_377_g1_proof_of_safe_subgroup_w = bigint_r("5285428838741532253824584287042945485047145357130994810877");
+    bls12_377_g1_proof_of_safe_subgroup_non_member_x = bls12_377_Fq(
+        "55791352246783872404788467909907092509364010229903880203689696498787615734938123558571181995209025075818229621722");
+    bls12_377_g1_proof_of_safe_subgroup_non_member_y = bls12_377_Fq(
+        "174363855833520138229666723484835348689236585013460554444609730120603741818916846216286948728983932214174344518655");
 
     // WNAF
     //

--- a/libff/algebra/curves/bls12_377/bls12_377_init.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_init.hpp
@@ -62,6 +62,9 @@ extern bls12_377_Fq2 bls12_377_twist_mul_by_q_Y;
 // Coefficient \beta in endomorphism (x, y) -> (\beta * x, y)
 extern bls12_377_Fq bls12_377_g1_endomorphism_beta;
 extern bigint<bls12_377_r_limbs> bls12_377_g1_safe_subgroup_check_c1;
+extern bigint<bls12_377_r_limbs> bls12_377_g1_proof_of_safe_subgroup_w;
+extern bls12_377_Fq bls12_377_g1_proof_of_safe_subgroup_non_member_x;
+extern bls12_377_Fq bls12_377_g1_proof_of_safe_subgroup_non_member_y;
 
 // Coefficients for G2 untwist-frobenius-twist
 extern bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_v;

--- a/libff/algebra/curves/bls12_377/bls12_377_init.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_init.hpp
@@ -50,6 +50,7 @@ typedef bls12_377_Fq12 bls12_377_GT;
 
 // Parameters for Barreto-Lynn-Scott curve E/Fq : y^2 = x^3 + b
 extern bls12_377_Fq bls12_377_coeff_b;
+extern bigint<bls12_377_r_limbs> bls12_377_trace_of_frobenius;
 // Parameters for twisted Barreto-Lynn-Scott curve E'/Fq2 : y^2 = x^3 + b/xi
 extern bls12_377_Fq2 bls12_377_twist;
 extern bls12_377_Fq2 bls12_377_twist_coeff_b;
@@ -57,6 +58,20 @@ extern bls12_377_Fq bls12_377_twist_mul_by_b_c0;
 extern bls12_377_Fq bls12_377_twist_mul_by_b_c1;
 extern bls12_377_Fq2 bls12_377_twist_mul_by_q_X;
 extern bls12_377_Fq2 bls12_377_twist_mul_by_q_Y;
+
+// Coefficient \beta in endomorphism (x, y) -> (\beta * x, y)
+extern bls12_377_Fq bls12_377_g1_endomorphism_beta;
+extern bigint<bls12_377_r_limbs> bls12_377_g1_safe_subgroup_check_c1;
+
+// Coefficients for G2 untwist-frobenius-twist
+extern bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_v;
+extern bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_w_3;
+extern bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_v_inverse;
+extern bls12_377_Fq12 bls12_377_g2_untwist_frobenius_twist_w_3_inverse;
+
+// Coefficients used in bls12_377_G2::mul_by_cofactor
+extern bigint<bls12_377_r_limbs> bls12_377_g2_mul_by_cofactor_h2_0;
+extern bigint<bls12_377_r_limbs> bls12_377_g2_mul_by_cofactor_h2_1;
 
 // Parameters for pairing
 extern bigint<bls12_377_q_limbs> bls12_377_ate_loop_count;

--- a/libff/algebra/curves/curve_utils.hpp
+++ b/libff/algebra/curves/curve_utils.hpp
@@ -17,6 +17,17 @@ namespace libff {
 template<typename GroupT, mp_size_t m>
 GroupT scalar_mul(const GroupT &base, const bigint<m> &scalar);
 
+// Utility function to compute a point on the curve E(Fq) with the given x
+// coordinate. If the curve has no solution, this function throws an
+// exception.
+template<typename GroupT>
+GroupT g1_curve_point_at_x(const typename GroupT::base_field &x);
+
+// Utility function to compute a point on the twisted curve E'(Fqe) with the
+// given x coordinate.
+template<typename GroupT>
+GroupT g2_curve_point_at_x(const typename GroupT::twist_field &x);
+
 } // libff
 #include <libff/algebra/curves/curve_utils.tcc>
 

--- a/libff/algebra/curves/curve_utils.tcc
+++ b/libff/algebra/curves/curve_utils.tcc
@@ -33,5 +33,35 @@ GroupT scalar_mul(const GroupT &base, const bigint<m> &scalar)
     return result;
 }
 
+template<typename GroupT>
+GroupT g1_curve_point_at_x(const typename GroupT::base_field &x)
+{
+    const typename GroupT::base_field x_squared = x * x;
+    const typename GroupT::base_field x_cubed = x_squared * x;
+    const typename GroupT::base_field y_squared =
+        x_cubed + (GroupT::coeff_a * x_squared) + GroupT::coeff_b;
+    // Check that y_squared is a quadratic residue (ensuring that sqrt()
+    // terminates).
+    if ((y_squared^GroupT::base_field::euler) != GroupT::base_field::one())
+    {
+        throw std::runtime_error("curve eqn has no solution at x");
+    }
+
+    const typename GroupT::base_field y = y_squared.sqrt();
+    return GroupT(x, y, GroupT::base_field::one());
+}
+
+template<typename GroupT>
+GroupT g2_curve_point_at_x(const typename GroupT::twist_field &x)
+{
+    const typename GroupT::twist_field x_squared = x * x;
+    const typename GroupT::twist_field x_cubed = x_squared * x;
+    const typename GroupT::twist_field y_squared =
+        x_cubed + (GroupT::coeff_a * x_squared) + GroupT::coeff_b;
+    // TODO: Generic check (over all fields) that y_squared.sqrt() terminates.
+    const typename GroupT::twist_field y = y_squared.sqrt();
+    return GroupT(x, y, GroupT::twist_field::one());
+}
+
 } // libff
 #endif // CURVE_UTILS_TCC_

--- a/libff/algebra/curves/profile/algebra_groups_profile.cpp
+++ b/libff/algebra/curves/profile/algebra_groups_profile.cpp
@@ -1,0 +1,58 @@
+/**
+ *****************************************************************************
+ * @author     This file is part of libff, developed by SCIPR Lab
+ *             and contributors (see AUTHORS).
+ * @copyright  MIT license (see LICENSE file)
+ *****************************************************************************/
+
+#include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
+#include <libff/common/profiling.hpp>
+
+#include <exception>
+
+using namespace libff;
+
+template<typename GroupT>
+bool profile_group_membership()
+{
+    static const size_t NUM_ELEMENTS = 1000;
+
+    // Measure the time taken to check membership of 1000 elements. (Note all
+    // elements are in fact members of the group - we are not testing
+    // correctness here).
+
+    std::vector<GroupT> elements;
+    elements.reserve(NUM_ELEMENTS);
+    for (size_t i = 0 ; i < NUM_ELEMENTS ; ++i)
+    {
+        elements.push_back(GroupT::random_element());
+    }
+
+    enter_block("group membership profiling");
+    for (const GroupT &el : elements)
+    {
+        if (!el.is_in_safe_subgroup())
+        {
+            return false;
+        }
+    }
+    leave_block("group membership profiling");
+
+    return true;
+}
+
+int main(void)
+{
+    std::cout << "bls12_377_pp\n";
+    bls12_377_pp::init_public_params();
+
+    std::cout << "profile_group_membership<bls12_377_G1>:\n";
+    if (!profile_group_membership<bls12_377_G1>()) {
+        throw std::runtime_error("failed");
+    }
+
+    std::cout << "profile_group_membership<bls12_377_G2>:\n";
+    if (!profile_group_membership<bls12_377_G2>()) {
+        throw std::runtime_error("failed");
+    }
+}

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -174,6 +174,35 @@ void test_group_membership_valid()
 }
 
 template<typename GroupT>
+bool profile_group_membership()
+{
+    static const size_t NUM_ELEMENTS = 1000;
+
+    // Measure the time taken to check membership of 1000 elements. (Note all
+    // elements are in fact members of the group - we are not testing
+    // correctness here).
+
+    std::vector<GroupT> elements;
+    elements.reserve(NUM_ELEMENTS);
+    for (size_t i = 0 ; i < NUM_ELEMENTS ; ++i)
+    {
+        elements.push_back(GroupT::random_element());
+    }
+
+    enter_block("group membership profiling");
+    for (const GroupT &el : elements)
+    {
+        if (!el.is_in_safe_subgroup())
+        {
+            return false;
+        }
+    }
+    leave_block("group membership profiling");
+
+    return true;
+}
+
+template<typename GroupT>
 void test_group_membership_invalid_g1(const typename GroupT::base_field &x)
 {
     const typename GroupT::base_field x_squared = x * x;
@@ -226,6 +255,8 @@ void test_check_membership<bls12_377_pp>()
     test_group_membership_invalid_g1<bls12_377_G1>(bls12_377_Fq(3));
     test_group_membership_invalid_g2<bls12_377_G2>(
         bls12_377_Fq(3) * bls12_377_Fq2::one());
+    assert(profile_group_membership<bls12_377_G1>());
+    assert(profile_group_membership<bls12_377_G2>());
 }
 
 template<>

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -20,26 +20,11 @@
 #include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
 #include <libff/algebra/curves/bls12_377/bls12_377_pp.hpp>
 #include <libff/algebra/curves/bw6_761/bw6_761_pp.hpp>
+#include <libff/algebra/curves/curve_utils.hpp>
 
 #include <sstream>
 
 using namespace libff;
-
-// Utility function to compute a point on the curve E(Fq) with the given x
-// coordinate.
-template<typename GroupT>
-GroupT curve_point_at_x(const typename GroupT::base_field &x)
-{
-    const typename GroupT::base_field x_squared = x * x;
-    const typename GroupT::base_field x_cubed = x_squared * x;
-    const typename GroupT::base_field y_squared =
-        x_cubed + (GroupT::coeff_a * x_squared) + GroupT::coeff_b;
-    // Assert that y_squared is in a quadatic residue (ensuring that sqrt()
-    // terminates).
-    assert((y_squared^GroupT::base_field::euler) == GroupT::base_field::one());
-    const typename GroupT::base_field y = y_squared.sqrt();
-    return GroupT(x, y, GroupT::base_field::one());
-}
 
 template<typename GroupT>
 void test_mixed_add()
@@ -202,7 +187,7 @@ void test_group_membership_proof_valid()
 template<typename GroupT>
 void test_group_membership_invalid_g1(const typename GroupT::base_field &x)
 {
-    const GroupT g1_invalid = curve_point_at_x<GroupT>(x);
+    const GroupT g1_invalid = g1_curve_point_at_x<GroupT>(x);
     assert(g1_invalid.is_well_formed());
     assert(!g1_invalid.is_in_safe_subgroup());
 }
@@ -210,7 +195,7 @@ void test_group_membership_invalid_g1(const typename GroupT::base_field &x)
 template<typename GroupT>
 void test_group_membership_proof_invalid_g1(const typename GroupT::base_field &x)
 {
-    const GroupT g1_invalid = curve_point_at_x<GroupT>(x);
+    const GroupT g1_invalid = g1_curve_point_at_x<GroupT>(x);
     const GroupT proof_of_membership = g1_invalid.proof_of_safe_subgroup();
     assert(proof_of_membership.mul_by_cofactor() != g1_invalid);
 }
@@ -218,13 +203,7 @@ void test_group_membership_proof_invalid_g1(const typename GroupT::base_field &x
 template<typename GroupT>
 void test_group_membership_invalid_g2(const typename GroupT::twist_field &x)
 {
-    const typename GroupT::twist_field x_squared = x * x;
-    const typename GroupT::twist_field x_cubed = x_squared * x;
-    const typename GroupT::twist_field y_squared =
-        x_cubed + (GroupT::coeff_a * x_squared) + GroupT::coeff_b;
-    const typename GroupT::twist_field y = y_squared.sqrt();
-    const GroupT g2_invalid(x, y, GroupT::twist_field::one());
-
+    const GroupT g2_invalid = g2_curve_point_at_x<GroupT>(x);
     assert(g2_invalid.is_well_formed());
     assert(!g2_invalid.is_in_safe_subgroup());
 }

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -14,7 +14,6 @@
 #include <libff/algebra/curves/edwards/edwards_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp>
 #include <libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp>
-#include <libff/common/profiling.hpp>
 #ifdef CURVE_BN128
 #include <libff/algebra/curves/bn128/bn128_pp.hpp>
 #endif
@@ -201,35 +200,6 @@ void test_group_membership_proof_valid()
 }
 
 template<typename GroupT>
-bool profile_group_membership()
-{
-    static const size_t NUM_ELEMENTS = 1000;
-
-    // Measure the time taken to check membership of 1000 elements. (Note all
-    // elements are in fact members of the group - we are not testing
-    // correctness here).
-
-    std::vector<GroupT> elements;
-    elements.reserve(NUM_ELEMENTS);
-    for (size_t i = 0 ; i < NUM_ELEMENTS ; ++i)
-    {
-        elements.push_back(GroupT::random_element());
-    }
-
-    enter_block("group membership profiling");
-    for (const GroupT &el : elements)
-    {
-        if (!el.is_in_safe_subgroup())
-        {
-            return false;
-        }
-    }
-    leave_block("group membership profiling");
-
-    return true;
-}
-
-template<typename GroupT>
 void test_group_membership_invalid_g1(const typename GroupT::base_field &x)
 {
     const GroupT g1_invalid = curve_point_at_x<GroupT>(x);
@@ -284,9 +254,6 @@ void test_check_membership<bls12_377_pp>()
     test_group_membership_invalid_g1<bls12_377_G1>(bls12_377_Fq(3));
     test_group_membership_invalid_g2<bls12_377_G2>(
         bls12_377_Fq(3) * bls12_377_Fq2::one());
-
-    assert(profile_group_membership<bls12_377_G1>());
-    assert(profile_group_membership<bls12_377_G2>());
 
     test_group_membership_proof_valid<bls12_377_G1>();
     test_group_membership_proof_invalid_g1<bls12_377_G1>(bls12_377_Fq(3));

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -129,6 +129,14 @@ void test_mul_by_q()
 }
 
 template<typename GroupT>
+void test_mul_by_cofactor()
+{
+    const GroupT a = GroupT::random_element();
+    const GroupT a_h = GroupT::h*a;
+    assert(a_h == a.mul_by_cofactor());
+}
+
+template<typename GroupT>
 void test_output()
 {
     GroupT g = GroupT::zero();
@@ -231,6 +239,7 @@ void test_check_membership<bw6_761_pp>()
 
 int main(void)
 {
+    std::cout << "edwards_pp\n";
     edwards_pp::init_public_params();
     test_group<G1<edwards_pp> >();
     test_output<G1<edwards_pp> >();
@@ -238,6 +247,7 @@ int main(void)
     test_output<G2<edwards_pp> >();
     test_mul_by_q<G2<edwards_pp> >();
 
+    std::cout << "mnt4_pp\n";
     mnt4_pp::init_public_params();
     test_group<G1<mnt4_pp> >();
     test_output<G1<mnt4_pp> >();
@@ -245,7 +255,10 @@ int main(void)
     test_output<G2<mnt4_pp> >();
     test_mul_by_q<G2<mnt4_pp> >();
     test_check_membership<mnt4_pp>();
+    test_mul_by_cofactor<G1<mnt4_pp>>();
+    test_mul_by_cofactor<G2<mnt4_pp>>();
 
+    std::cout << "mnt6_pp\n";
     mnt6_pp::init_public_params();
     test_group<G1<mnt6_pp> >();
     test_output<G1<mnt6_pp> >();
@@ -253,7 +266,10 @@ int main(void)
     test_output<G2<mnt6_pp> >();
     test_mul_by_q<G2<mnt6_pp> >();
     test_check_membership<mnt6_pp>();
+    test_mul_by_cofactor<G1<mnt6_pp>>();
+    test_mul_by_cofactor<G2<mnt6_pp>>();
 
+    std::cout << "alt_bn128_pp\n";
     alt_bn128_pp::init_public_params();
     test_group<G1<alt_bn128_pp> >();
     test_output<G1<alt_bn128_pp> >();
@@ -261,8 +277,11 @@ int main(void)
     test_output<G2<alt_bn128_pp> >();
     test_mul_by_q<G2<alt_bn128_pp> >();
     test_check_membership<alt_bn128_pp>();
+    test_mul_by_cofactor<G1<alt_bn128_pp>>();
+    test_mul_by_cofactor<G2<alt_bn128_pp>>();
 
     // Make sure that added curves pass the libff tests
+    std::cout << "bls12_377_pp\n";
     bls12_377_pp::init_public_params();
     test_group<G1<bls12_377_pp> >();
     test_output<G1<bls12_377_pp> >();
@@ -270,7 +289,10 @@ int main(void)
     test_output<G2<bls12_377_pp> >();
     test_mul_by_q<G2<bls12_377_pp> >();
     test_check_membership<bls12_377_pp>();
+    test_mul_by_cofactor<G1<bls12_377_pp>>();
+    test_mul_by_cofactor<G2<bls12_377_pp>>();
 
+    std::cout << "bw6_761_pp\n";
     bw6_761_pp::init_public_params();
     test_group<G1<bw6_761_pp> >();
     test_output<G1<bw6_761_pp> >();
@@ -278,14 +300,19 @@ int main(void)
     test_output<G2<bw6_761_pp> >();
     test_mul_by_q<G2<bw6_761_pp> >();
     test_check_membership<bw6_761_pp>();
+    test_mul_by_cofactor<G1<bw6_761_pp>>();
+    test_mul_by_cofactor<G2<bw6_761_pp>>();
 
 // BN128 has fancy dependencies so it may be disabled
 #ifdef CURVE_BN128
+    std::cout << "bn128_pp\n";
     bn128_pp::init_public_params();
     test_group<G1<bn128_pp> >();
     test_output<G1<bn128_pp> >();
     test_group<G2<bn128_pp> >();
     test_output<G2<bn128_pp> >();
     test_check_membership<bn128_pp>();
+    test_mul_by_cofactor<G1<bn128_pp>>();
+    test_mul_by_cofactor<G2<bn128_pp>>();
 #endif
 }

--- a/libff/algebra/curves/tests/test_groups.cpp
+++ b/libff/algebra/curves/tests/test_groups.cpp
@@ -268,6 +268,25 @@ void test_check_membership<bw6_761_pp>()
     test_group_membership_invalid_g2<bw6_761_G2>(bw6_761_Fq(0));
 }
 
+void test_bls12_377()
+{
+    const bls12_377_G1 g1 = bls12_377_G1::random_element();
+
+    // Ensure sigma endomorphism results in multiplication by expected lambda.
+    const bls12_377_G1 sigma_g1 = g1.sigma();
+    assert(
+        (bls12_377_Fr("91893752504881257701523279626832445440") * g1) ==
+        sigma_g1);
+
+    // Ensure untwist-frobenius-twist operation \psi satisfies:
+    //   \psi^2(P) - [t] \psi(P) + [q]P = zero
+    const bls12_377_G2 a = bls12_377_G2::random_element();
+    const bls12_377_G2 uft = a.untwist_frobenius_twist();
+    const bls12_377_G2 uft_2 = uft.untwist_frobenius_twist();
+    const bls12_377_G2 z = uft_2 - (bls12_377_trace_of_frobenius * uft) + (bls12_377_modulus_q * a);
+    assert(z == bls12_377_G2::zero());
+}
+
 int main(void)
 {
     std::cout << "edwards_pp\n";
@@ -314,6 +333,7 @@ int main(void)
     // Make sure that added curves pass the libff tests
     std::cout << "bls12_377_pp\n";
     bls12_377_pp::init_public_params();
+    test_bls12_377();
     test_group<G1<bls12_377_pp> >();
     test_output<G1<bls12_377_pp> >();
     test_group<G2<bls12_377_pp> >();


### PR DESCRIPTION
All changes are specific to BLS12-377:
- [X] Optimized checks for subgroup membership of G1 and G2 (based on endomorphisms)
- [X] Faster G2::mul_by_cofactor() implementation
- [X] Method to generate P' (for P in G1) s.t. [h]P' = P

Final point here is potentially useful for efficient verification in zero-knowledge proofs.  (Note that the equivalent approach in G2 is not as efficient as the optimized direct membership check.)