### PR TITLE
Msm with signed digits (depends on #48)

### DIFF
--- a/libff/CMakeLists.txt
+++ b/libff/CMakeLists.txt
@@ -116,6 +116,19 @@ if ("${IS_LIBFF_PARENT}")
     gtest_main
   )
 
+  add_executable(
+    algebra_multiexp_test
+    EXCLUDE_FROM_ALL
+
+    algebra/scalar_multiplication/test_multiexp.cpp
+  )
+  target_link_libraries(
+    algebra_multiexp_test
+
+    ff
+    gtest_main
+  )
+
   include(CTest)
   add_test(
     NAME algebra_bilinearity_test
@@ -130,9 +143,15 @@ if ("${IS_LIBFF_PARENT}")
     COMMAND algebra_fields_test
   )
 
+  add_test(
+    NAME algebra_multiexp_test
+    COMMAND algebra_multiexp_test
+  )
+
   add_dependencies(check algebra_bilinearity_test)
   add_dependencies(check algebra_groups_test)
   add_dependencies(check algebra_fields_test)
+  add_dependencies(check algebra_multiexp_test)
 
   add_executable(
     multiexp_profile

--- a/libff/algebra/curves/profile/algebra_groups_profile.cpp
+++ b/libff/algebra/curves/profile/algebra_groups_profile.cpp
@@ -12,35 +12,74 @@
 
 using namespace libff;
 
+/// Number of random elements to generate (since this process is expensive)
+static const size_t ADD_NUM_DIFFERENT_ELEMENTS = 1024;
+
+/// Number of element to operate on in a single iteration.
+static const size_t ADD_NUM_ELEMENTS = 1024 * 1024;
+
 template<typename GroupT> bool profile_group_add()
 {
-    static const size_t NUM_DIFFERENT_ELEMENTS = 1024;
-    static const size_t NUM_ELEMENTS = 1024 * 1024;
-
     std::vector<GroupT> elements;
     {
-        elements.reserve(NUM_ELEMENTS);
+        elements.reserve(ADD_NUM_ELEMENTS);
         size_t i = 0;
-        for (; i < NUM_DIFFERENT_ELEMENTS; ++i) {
+        for (; i < ADD_NUM_DIFFERENT_ELEMENTS; ++i) {
             elements.push_back(GroupT::random_element());
         }
-        for (; i < NUM_ELEMENTS; ++i) {
-            elements.push_back(elements[i % NUM_DIFFERENT_ELEMENTS]);
+        for (; i < ADD_NUM_ELEMENTS; ++i) {
+            elements.push_back(elements[i % ADD_NUM_DIFFERENT_ELEMENTS]);
         }
     }
 
-    std::cout << "    num elements: " << std::to_string(NUM_ELEMENTS) << "\n";
+    std::cout << "    num elements: " << std::to_string(ADD_NUM_ELEMENTS)
+              << "\n";
 
     size_t num_elements = 0;
     GroupT accum = GroupT::zero();
     enter_block("group add operation profiling");
     for (const GroupT &el : elements) {
-        accum = accum + el;
+        accum = accum.add(el);
         num_elements++;
     }
     leave_block("group add operation profiling");
 
-    if (num_elements != NUM_ELEMENTS) {
+    if (num_elements != ADD_NUM_ELEMENTS) {
+        throw std::runtime_error("invalid number of elements seen");
+    }
+
+    return true;
+}
+
+template<typename GroupT> bool profile_group_mixed_add()
+{
+    std::vector<GroupT> elements;
+    {
+        elements.reserve(ADD_NUM_ELEMENTS);
+        size_t i = 0;
+        for (; i < ADD_NUM_DIFFERENT_ELEMENTS; ++i) {
+            GroupT e = GroupT::random_element();
+            e.to_affine_coordinates();
+            elements.push_back(e);
+        }
+        for (; i < ADD_NUM_ELEMENTS; ++i) {
+            elements.push_back(elements[i % ADD_NUM_DIFFERENT_ELEMENTS]);
+        }
+    }
+
+    std::cout << "    num elements: " << std::to_string(ADD_NUM_ELEMENTS)
+              << "\n";
+
+    size_t num_elements = 0;
+    GroupT accum = GroupT::one();
+    enter_block("group mixed add operation profiling");
+    for (const GroupT &el : elements) {
+        accum = accum.mixed_add(el);
+        num_elements++;
+    }
+    leave_block("group mixed add operation profiling");
+
+    if (num_elements != ADD_NUM_ELEMENTS) {
         throw std::runtime_error("invalid number of elements seen");
     }
 
@@ -82,8 +121,18 @@ int main(void)
         throw std::runtime_error("failed");
     }
 
+    std::cout << "  profile_group_mixed_add<alt_bn128_G1>:\n";
+    if (!profile_group_mixed_add<alt_bn128_G1>()) {
+        throw std::runtime_error("failed");
+    }
+
     std::cout << "  profile_group_add<alt_bn128_G2>:\n";
     if (!profile_group_add<alt_bn128_G2>()) {
+        throw std::runtime_error("failed");
+    }
+
+    std::cout << "  profile_group_mixed_add<alt_bn128_G2>:\n";
+    if (!profile_group_mixed_add<alt_bn128_G2>()) {
         throw std::runtime_error("failed");
     }
 
@@ -92,6 +141,11 @@ int main(void)
 
     std::cout << "  profile_group_add<bls12_377_G1>:\n";
     if (!profile_group_add<bls12_377_G1>()) {
+        throw std::runtime_error("failed");
+    }
+
+    std::cout << "  profile_group_mixed_add<bls12_377_G1>:\n";
+    if (!profile_group_mixed_add<bls12_377_G1>()) {
         throw std::runtime_error("failed");
     }
 

--- a/libff/algebra/fields/field_utils.hpp
+++ b/libff/algebra/fields/field_utils.hpp
@@ -24,6 +24,16 @@ template<typename FieldT>
 typename std::enable_if<!std::is_same<FieldT, Double>::value, FieldT>::type
 get_root_of_unity(const size_t n);
 
+/// Decompose v into fixed-size digits of digit_size bits each.
+template<mp_size_t n>
+size_t field_get_digit(
+    const bigint<n> &v, const size_t digit_size, const size_t digit_index);
+
+/// Decompose v into fixed-size signed digits of digit_size bits each.
+template<mp_size_t n>
+ssize_t field_get_signed_digit(
+    const bigint<n> &v, const size_t digit_size, const size_t digit_index);
+
 template<typename FieldT>
 std::vector<FieldT> pack_int_vector_into_field_element_vector(
     const std::vector<size_t> &v, const size_t w);

--- a/libff/algebra/fields/field_utils.tcc
+++ b/libff/algebra/fields/field_utils.tcc
@@ -11,12 +11,80 @@
 #define FIELD_UTILS_TCC_
 
 #include <complex>
+#include <libff/algebra/fields/bigint.hpp>
 #include <libff/common/double.hpp>
 #include <libff/common/utils.hpp>
 #include <stdexcept>
 
 namespace libff
 {
+
+template<mp_size_t n>
+size_t field_get_digit(
+    const bigint<n> &v, const size_t digit_size, const size_t digit_idx)
+{
+    constexpr size_t limb_size_bits = 8 * sizeof(v.data[0]);
+    const size_t start_bit = digit_size * digit_idx;
+    const size_t end_bit = start_bit + digit_size;
+    const size_t low_limb = start_bit / limb_size_bits;
+    const size_t high_limb = end_bit / limb_size_bits;
+
+    // use_high_limb = (high_limb < n) && (high_limb != low_limb)
+    //               = (1 - (n - 1 - high_limb) >> limb_size_bits) &&
+    //                   (high_limb - low_limb)
+    const size_t use_high_limb =
+        (1 - ((n - 1 - high_limb) >> (limb_size_bits - 1))) &
+        (high_limb - low_limb);
+    assert(use_high_limb == ((high_limb < n) && (high_limb != low_limb)));
+    const size_t low_limb_shift = start_bit - low_limb * limb_size_bits;
+
+    // if use_high_limb == 0, then high_limb_shift = c, which causes any high
+    // limb data to be shifted outside of the mask.
+    const size_t high_limb_bits =
+        use_high_limb * (end_bit - high_limb * limb_size_bits);
+    const size_t high_limb_shift = digit_size - high_limb_bits;
+
+    const size_t mask = (1ull << digit_size) - 1;
+
+    return mask & ((v.data[use_high_limb * high_limb] << high_limb_shift) |
+                   (v.data[low_limb] >> low_limb_shift));
+}
+
+template<mp_size_t n>
+ssize_t field_get_signed_digit(
+    const bigint<n> &v, const size_t digit_size, const size_t digit_index)
+{
+    //  digit            x x x x
+    //  carry_mask       1 0 0 0
+    //  overflow_mask  1 0 0 0 0
+    const size_t carry_mask = 1ull << (digit_size - 1);
+    const ssize_t overflow_mask = 1ll << digit_size;
+    size_t carry = 0;
+    ssize_t overflow = 0;
+    size_t digit;
+    size_t i = 0;
+
+    // For each digit:
+    //   if overflow, then digit = 0, carry = 1
+    //   if carry, digit = digit - overflow_mask,
+    //     (because overflow_mask is also the value added when carrying into
+    //      in the next digit)
+    //   else digit = digit
+
+    do {
+        // This is done at the start of the loop, rather than the end, since
+        // the individual values (before this OR) are required to compute the
+        // final value when this loop terminates.
+        carry = overflow | carry;
+
+        digit = field_get_digit(v, digit_size, i) + carry;
+        overflow = (digit & overflow_mask) >> digit_size; // 1/0
+        carry = (digit & carry_mask) >> (digit_size - 1); // 1/0
+        ++i;
+    } while (i <= digit_index);
+
+    return (1 - overflow) * (digit - (carry * overflow_mask));
+}
 
 template<typename FieldT> FieldT coset_shift()
 {

--- a/libff/algebra/scalar_multiplication/multiexp.hpp
+++ b/libff/algebra/scalar_multiplication/multiexp.hpp
@@ -45,7 +45,16 @@ enum multi_exp_method {
      * Requires that T implements .dbl() (and, if USE_MIXED_ADDITION is defined,
      * .to_special(), .mixed_add(), and batch_to_special()).
      */
-    multi_exp_method_BDLO12
+    multi_exp_method_BDLO12,
+    /**
+     * Similar to multi_exp_method_BDLO12, but using signed digits.
+     */
+    multi_exp_method_BDLO12_signed,
+    /**
+     * Similar to multi_exp_method_BDLO12_signed, using mixed addition
+     * (requiring affine base elements).
+     */
+    multi_exp_method_BDLO12_signed_mixed,
 };
 
 /**

--- a/libff/algebra/scalar_multiplication/multiexp.tcc
+++ b/libff/algebra/scalar_multiplication/multiexp.tcc
@@ -27,6 +27,232 @@
 namespace libff
 {
 
+size_t pippenger_optimal_c(const size_t num_elements)
+{
+    // empirically, this seems to be a decent estimate of the optimal value of c
+    const size_t log2_num_elements = log2(num_elements);
+    return log2_num_elements - (log2_num_elements / 3 - 2);
+}
+
+/// Compute:
+///   \sum_{i=1}^{num_buckets} [i] B_i
+/// where
+///   B_i is the i-th bucket value (stored in buckets[i - 1])
+///
+/// Caller must ensure that at least one bucket is not empty (i.e.
+/// bucket_hit[i] == true for at least one i).
+template<typename GroupT>
+GroupT multiexp_accumulate_buckets(
+    std::vector<GroupT> &buckets,
+    std::vector<bool> &bucket_hit,
+    const size_t num_buckets)
+{
+    // Find first set bucket and initialize the accumulator. For each remaining
+    // buckets (set or unset), add the bucket value to the accumulator (if
+    // set), and add the accumulator to the sum. In this way, the i-th bucket
+    // will be added to sum exactly i times.
+
+    size_t i = num_buckets - 1;
+    while (!bucket_hit[i]) {
+        --i;
+
+        // Ensure that at least one bucket is initialized.
+        assert(i < num_buckets);
+    }
+
+    GroupT sum;
+    GroupT accumulator;
+    sum = accumulator = buckets[i];
+    while (i > 0) {
+        --i;
+        if (bucket_hit[i]) {
+            accumulator = accumulator + buckets[i];
+        }
+        sum = sum + accumulator;
+    }
+
+    return sum;
+}
+
+/// buckets and bucket_hit should have at least 2^{c-1] entries.
+template<typename GroupT, typename BigIntT, bool MixedAddition>
+GroupT multiexp_signed_digits_round(
+    typename std::vector<GroupT>::const_iterator bases,
+    typename std::vector<GroupT>::const_iterator bases_end,
+    typename std::vector<BigIntT>::const_iterator exponents,
+    std::vector<GroupT> &buckets,
+    std::vector<bool> &bucket_hit,
+    const size_t num_entries,
+    const size_t num_buckets,
+    const size_t c,
+    const size_t digit_idx)
+{
+    UNUSED(bases_end);
+
+    assert(buckets.size() >= num_buckets);
+    assert(bucket_hit.size() >= num_buckets);
+
+    // Zero bucket_hit array.
+    bucket_hit.assign(num_buckets, false);
+
+    // For each scalar, element pair
+    size_t num_buckets_initialized = 0;
+    for (size_t i = 0; i < num_entries; ++i) {
+        const ssize_t digit =
+            field_get_signed_digit(exponents[i], c, digit_idx);
+        if (digit == 0) {
+            continue;
+        }
+
+        // Unroll each branch, to avoid copying the group elements.
+        if (digit < 0) {
+            const size_t bucket_idx = (-digit) - 1;
+            assert(bucket_idx < num_buckets);
+            if (bucket_hit[bucket_idx]) {
+                if (MixedAddition) {
+                    buckets[bucket_idx] =
+                        buckets[bucket_idx].mixed_add(-bases[i]);
+                } else {
+                    buckets[bucket_idx] = buckets[bucket_idx].add(-bases[i]);
+                }
+            } else {
+                buckets[bucket_idx] = -bases[i];
+                bucket_hit[bucket_idx] = true;
+                ++num_buckets_initialized;
+            }
+        } else {
+            const size_t bucket_idx = digit - 1;
+            assert(bucket_idx < num_buckets);
+            if (bucket_hit[bucket_idx]) {
+                if (MixedAddition) {
+                    buckets[bucket_idx] =
+                        buckets[bucket_idx].mixed_add(bases[i]);
+                } else {
+                    buckets[bucket_idx] = buckets[bucket_idx].add(bases[i]);
+                }
+            } else {
+                buckets[bucket_idx] = bases[i];
+                bucket_hit[bucket_idx] = true;
+                ++num_buckets_initialized;
+            }
+        }
+    }
+
+    // Check up-front for the edge-case where no buckets have been touched.
+    if (num_buckets_initialized == 0) {
+        return GroupT::zero();
+    }
+
+    return multiexp_accumulate_buckets(buckets, bucket_hit, num_buckets);
+}
+
+template<typename GroupT, typename FieldT, bool MixedAddition>
+GroupT multiexp_signed_digits(
+    typename std::vector<GroupT>::const_iterator bases,
+    typename std::vector<GroupT>::const_iterator bases_end,
+    typename std::vector<FieldT>::const_iterator exponents,
+    typename std::vector<FieldT>::const_iterator exponents_end)
+{
+    UNUSED(exponents_end);
+
+    const size_t num_entries = bases_end - bases;
+    assert(exponents_end - exponents == (ssize_t)num_entries);
+    const size_t c = pippenger_optimal_c(num_entries) + 1;
+    assert(c > 0);
+    using bigint_t =
+        typename std::decay<decltype(((FieldT *)nullptr)->mont_repr)>::type;
+
+    // Pre-compute the bigint values
+    size_t num_bits = 0;
+    std::vector<bigint_t> bi_exponents(num_entries);
+    for (size_t i = 0; i < num_entries; ++i) {
+        bi_exponents[i] = exponents[i].as_bigint();
+        num_bits = std::max(num_bits, bi_exponents[i].num_bits());
+    }
+
+    const size_t num_rounds = (num_bits + c - 1) / c;
+
+    // Digits have values between -(2^{c-1}) and 2^{c-1} - 1. Negative values
+    // are negated (to make them positive since we have cheap inversion of base
+    // elements), and 0 values are ignored. Hence we require up to 2^{c-1}
+    // buckets
+    const size_t num_buckets = 1 << (c - 1);
+
+    // Allocate the round state once, and reuse it.
+    std::vector<GroupT> buckets(num_buckets);
+    std::vector<bool> bucket_hit(num_buckets);
+    assert(buckets.size() == num_buckets);
+    assert(bucket_hit.size() == num_buckets);
+
+    // Compute from highest-order to lowest-order digits, accumulating at the
+    // same time.
+    GroupT result =
+        multiexp_signed_digits_round<GroupT, bigint_t, MixedAddition>(
+            bases,
+            bases_end,
+            bi_exponents.begin(),
+            buckets,
+            bucket_hit,
+            num_entries,
+            num_buckets,
+            c,
+            num_rounds - 1);
+    for (size_t round_idx = 1; round_idx < num_rounds; ++round_idx) {
+        const size_t digit_idx = num_rounds - 1 - round_idx;
+        for (size_t i = 0; i < c; ++i) {
+            result = result.dbl();
+        }
+
+        const GroupT round_result =
+            multiexp_signed_digits_round<GroupT, bigint_t, MixedAddition>(
+                bases,
+                bases_end,
+                bi_exponents.begin(),
+                buckets,
+                bucket_hit,
+                num_entries,
+                num_buckets,
+                c,
+                digit_idx);
+        result = result + round_result;
+    }
+
+    return result;
+}
+
+template<
+    typename GroupT,
+    typename FieldT,
+    multi_exp_method Method,
+    typename std::enable_if<(Method == multi_exp_method_BDLO12_signed), int>::
+        type = 0>
+GroupT multi_exp_inner(
+    typename std::vector<GroupT>::const_iterator bases,
+    typename std::vector<GroupT>::const_iterator bases_end,
+    typename std::vector<FieldT>::const_iterator exponents,
+    typename std::vector<FieldT>::const_iterator exponents_end)
+{
+    return multiexp_signed_digits<GroupT, FieldT, false>(
+        bases, bases_end, exponents, exponents_end);
+}
+
+template<
+    typename GroupT,
+    typename FieldT,
+    multi_exp_method Method,
+    typename std::enable_if<
+        (Method == multi_exp_method_BDLO12_signed_mixed),
+        int>::type = 0>
+GroupT multi_exp_inner(
+    typename std::vector<GroupT>::const_iterator bases,
+    typename std::vector<GroupT>::const_iterator bases_end,
+    typename std::vector<FieldT>::const_iterator exponents,
+    typename std::vector<FieldT>::const_iterator exponents_end)
+{
+    return multiexp_signed_digits<GroupT, FieldT, true>(
+        bases, bases_end, exponents, exponents_end);
+}
+
 template<mp_size_t n> class ordered_exponent
 {
     // to use std::push_heap and friends later
@@ -178,11 +404,8 @@ T multi_exp_inner(
     typename std::vector<FieldT>::const_iterator exponents_end)
 {
     UNUSED(exponents_end);
-    size_t length = bases_end - bases;
-
-    // empirically, this seems to be a decent estimate of the optimal value of c
-    size_t log2_length = log2(length);
-    size_t c = log2_length - (log2_length / 3 - 2);
+    const size_t length = bases_end - bases;
+    const size_t c = pippenger_optimal_c(length);
 
     const mp_size_t exp_num_limbs =
         std::remove_reference<decltype(*exponents)>::type::num_limbs;
@@ -194,7 +417,7 @@ T multi_exp_inner(
         num_bits = std::max(num_bits, bn_exponents[i].num_bits());
     }
 
-    size_t num_groups = (num_bits + c - 1) / c;
+    const size_t num_groups = (num_bits + c - 1) / c;
 
     T result;
     bool result_nonzero = false;

--- a/libff/algebra/scalar_multiplication/multiexp_profile.cpp
+++ b/libff/algebra/scalar_multiplication/multiexp_profile.cpp
@@ -75,6 +75,13 @@ void print_performance_csv(
     size_t expn_end_naive,
     bool compare_answers)
 {
+    printf(
+        "\t%16s\t%16s\t%16s\t%16s\t%16s\n",
+        "bos-coster",
+        "djb",
+        "djb_signed",
+        "djb_signed_mixed",
+        "naive");
     for (size_t expn = expn_start; expn <= expn_end_fast; expn++) {
         printf("%ld", expn);
         fflush(stdout);
@@ -87,13 +94,13 @@ void print_performance_csv(
         run_result_t<GroupT> result_bos_coster =
             profile_multiexp<GroupT, FieldT, multi_exp_method_bos_coster>(
                 group_elements, scalars);
-        printf("\t%20lld", result_bos_coster.first);
+        printf("\t%16lld", result_bos_coster.first);
         fflush(stdout);
 
         run_result_t<GroupT> result_djb =
             profile_multiexp<GroupT, FieldT, multi_exp_method_BDLO12>(
                 group_elements, scalars);
-        printf("\t%20lld", result_djb.first);
+        printf("\t%16lld", result_djb.first);
         fflush(stdout);
 
         if (compare_answers &&
@@ -101,11 +108,36 @@ void print_performance_csv(
             fprintf(stderr, "Answers NOT MATCHING (bos coster != djb)\n");
         }
 
+        run_result_t<GroupT> result_djb_signed =
+            profile_multiexp<GroupT, FieldT, multi_exp_method_BDLO12_signed>(
+                group_elements, scalars);
+        printf("\t%16lld", result_djb_signed.first);
+        fflush(stdout);
+
+        if (compare_answers &&
+            (result_djb.second != result_djb_signed.second)) {
+            fprintf(stderr, "Answers NOT MATCHING (djb != djb_signed)\n");
+        }
+
+        run_result_t<GroupT> result_djb_signed_mixed = profile_multiexp<
+            GroupT,
+            FieldT,
+            multi_exp_method_BDLO12_signed_mixed>(group_elements, scalars);
+        printf("\t%16lld", result_djb_signed_mixed.first);
+        fflush(stdout);
+
+        if (compare_answers &&
+            (result_djb_signed.second != result_djb_signed_mixed.second)) {
+            fprintf(
+                stderr,
+                "Answers NOT MATCHING (djb_signed != djb_signed_mixed)\n");
+        }
+
         if (expn <= expn_end_naive) {
             run_result_t<GroupT> result_naive =
                 profile_multiexp<GroupT, FieldT, multi_exp_method_naive>(
                     group_elements, scalars);
-            printf("\t%20lld", result_naive.first);
+            printf("\t%16lld", result_naive.first);
             fflush(stdout);
 
             if (compare_answers &&

--- a/libff/algebra/scalar_multiplication/test_multiexp.cpp
+++ b/libff/algebra/scalar_multiplication/test_multiexp.cpp
@@ -1,0 +1,175 @@
+#include <gtest/gtest.h>
+#include <libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp>
+#include <libff/algebra/scalar_multiplication/multiexp.hpp>
+
+using namespace libff;
+
+namespace
+{
+
+template<typename GroupT>
+void test_multiexp_accumulate_buckets(const size_t num_buckets)
+{
+    using FieldT = typename GroupT::scalar_field;
+
+    // Prepare values
+    std::vector<GroupT> values;
+    values.reserve(num_buckets);
+    std::vector<bool> value_hit;
+    value_hit.reserve(num_buckets);
+    for (size_t i = 0; i < num_buckets; ++i) {
+        const bool hit = rand() % 2;
+        value_hit.push_back(hit);
+        values.push_back(GroupT::random_element());
+    }
+
+    // Expected value
+    GroupT expected = GroupT::zero();
+    for (size_t i = 0; i < num_buckets; ++i) {
+        if (value_hit[i]) {
+            expected = expected + (FieldT(i + 1) * values[i]);
+        }
+    }
+
+    // Actual value
+    const GroupT actual =
+        multiexp_accumulate_buckets(values, value_hit, num_buckets);
+
+    ASSERT_EQ(expected, actual);
+}
+
+template<typename GroupT, bool MixedAddition>
+void test_multiexp_signed_digits_round(const size_t digit_idx)
+{
+    using FieldT = typename GroupT::scalar_field;
+    using BigIntT =
+        typename std::decay<decltype(FieldT::one().as_bigint())>::type;
+
+    const size_t c = 4;
+    const size_t num_buckets = 8; // 1 << (4 - 1);;
+
+    // Prepare values
+    std::vector<GroupT> bases{
+        FieldT(1) * GroupT::one(),
+        FieldT(2) * GroupT::one(),
+        FieldT(3) * GroupT::one(),
+        FieldT(3) * GroupT::one(),
+        FieldT(3) * GroupT::one(),
+        FieldT(4) * GroupT::one(),
+    };
+    std::vector<BigIntT> exponents{
+        FieldT(4 << (c * digit_idx)).as_bigint(),
+        FieldT(3 << (c * digit_idx)).as_bigint(),
+        FieldT(2 << (c * digit_idx)).as_bigint(),
+        FieldT(256 << (c * digit_idx)).as_bigint(), // ignored (digit = 0)
+        FieldT(256 << (c * digit_idx)).as_bigint(), // ignored (digit = 0)
+        FieldT(1 << (c * digit_idx)).as_bigint(),
+    };
+
+    // Prepare state (use 4 bits, to recover the original scalar values).
+    const size_t num_entries = bases.size();
+    std::vector<GroupT> buckets(num_buckets);
+    std::vector<bool> bucket_hit(num_buckets);
+
+    // Expected result is:
+    //     4 * [1] + 3 * [2] + 2 * [3] + + 0 * [3] + 0 * [3] + 1 * [4]
+    //   = [4] + [6] + [6] + 4
+    //   = [20]
+    const GroupT expected = FieldT(20) * GroupT::one();
+
+    // Actual value
+    const GroupT actual =
+        multiexp_signed_digits_round<GroupT, BigIntT, MixedAddition>(
+            bases.begin(),
+            bases.end(),
+            exponents.begin(),
+            buckets,
+            bucket_hit,
+            num_entries,
+            num_buckets,
+            c,
+            digit_idx);
+
+    ASSERT_EQ(expected, actual);
+}
+
+template<typename GroupT, multi_exp_method Method> void test_multiexp_inner()
+{
+    using FieldT = typename GroupT::scalar_field;
+
+    const size_t c = 4;
+
+    // Prepare values
+    std::vector<GroupT> bases{
+        FieldT(1) * GroupT::one(),
+        FieldT(2) * GroupT::one(),
+        FieldT(3) * GroupT::one(),
+        FieldT(4) * GroupT::one(),
+        FieldT(1) * GroupT::one(),
+        FieldT(2) * GroupT::one(),
+        FieldT(3) * GroupT::one(),
+        FieldT(4) * GroupT::one(),
+    };
+    for (auto &b : bases) {
+        b.to_affine_coordinates();
+    }
+
+    std::vector<FieldT> exponents{
+        FieldT(4 << (c * 0)),
+        FieldT(3 << (c * 1)),
+        FieldT(2 << (c * 2)),
+        FieldT(1 << (c * 3)),
+        FieldT(4 << (c * 0)),
+        FieldT(3 << (c * 1)),
+        FieldT(2 << (c * 2)),
+        FieldT(1 << (c * 3)),
+    };
+
+    // Expected result is:
+    //     4 * [1] + (3 << c) * [2] + (2 << (2*c)) * [3] + (1 << (3*c)) * [4]
+    //   = [4] + [6] + [6] + 4
+    //   = [20]
+    const long expected_unencoded =
+        2 * ((4 << 0) + ((3 << c) * 2) + ((2 << (2 * c)) * 3) +
+             ((1 << (3 * c)) * 4));
+    const GroupT expected = FieldT(expected_unencoded) * GroupT::one();
+
+    // Actual value
+    const GroupT actual = multi_exp_inner<GroupT, FieldT, Method>(
+        bases.begin(), bases.end(), exponents.begin(), exponents.end());
+
+    ASSERT_EQ(expected, actual);
+}
+
+TEST(MultiExpTest, TestMultiExpAccumulateBuckets)
+{
+    test_multiexp_accumulate_buckets<alt_bn128_G1>(4);
+    test_multiexp_accumulate_buckets<alt_bn128_G1>(16);
+    test_multiexp_accumulate_buckets<alt_bn128_G1>(128);
+}
+
+TEST(MultiExpTest, TestMultiExpSignedDigitsRound)
+{
+    test_multiexp_signed_digits_round<alt_bn128_G1, false>(0);
+    test_multiexp_signed_digits_round<alt_bn128_G1, true>(0);
+    test_multiexp_signed_digits_round<alt_bn128_G1, false>(1);
+    test_multiexp_signed_digits_round<alt_bn128_G1, true>(1);
+    test_multiexp_signed_digits_round<alt_bn128_G1, false>(2);
+    test_multiexp_signed_digits_round<alt_bn128_G1, true>(2);
+    test_multiexp_signed_digits_round<alt_bn128_G1, false>(3);
+    test_multiexp_signed_digits_round<alt_bn128_G1, true>(3);
+}
+
+TEST(MultiExpTest, TestMultiExpInner)
+{
+    test_multiexp_inner<alt_bn128_G1, multi_exp_method_BDLO12_signed_mixed>();
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+    libff::alt_bn128_pp::init_public_params();
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Implement a version of the multiexp BDLO12 algo which uses signed digits, and fewer buckets.

```
Profiling BN128_G1                                                                                                                                                                                 
          bos-coster                 djb          djb_signed    djb_signed_mixed               naive                                                                                               
15        4390146354          3621831568          2559170393          2329989354                                                                                                                   
16        8688658502          6677310326          4859663485          4404485942                                                                                                                   
17       17423220142         12708646808          8872146439          8077118042                                                                                                                   
18       35624427747         24571309372         17155684557         15022609716                                                                                                                   
19       73408686593         46807624586         33582271798         29590625743                                                                                                                   
Profiling BN128_G2                                                                                                                                                                                 
          bos-coster                 djb          djb_signed    djb_signed_mixed               naive                                                                                               
15        9957599682          9344146901          6184755967          5439346715                                                                                                                   
16       19036943597         17436614440         11697143042         10381935253                                                                                                                   
17       37138535251         33345563948         21654660284         19289333794                                                                                                                   
18       73289131851         63958431914         41346268602         35600374933                                                                                                                   
19      145587724992        119301015290         79703810901         69525408926                                                                                                                   
```