### PR TITLE
fix openssl support on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,6 @@ set_target_properties(
 )
 
 find_package(OpenSSL REQUIRED)
-INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR})
 
 if("${WITH_PROCPS}")
   include(FindPkgConfig)

--- a/libff/CMakeLists.txt
+++ b/libff/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(
 )
 target_include_directories(
   ff
-  PUBLIC ..
+  PUBLIC .. ${OPENSSL_INCLUDE_DIR}
 )
 
 install(


### PR DESCRIPTION
Use correct include path for openssl, when installed via brew.