### PR TITLE
Switched to https in submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/herumi/xbyak.git
 [submodule "depends/gtest"]
 	path = depends/gtest
-	url = git://github.com/google/googletest.git
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
The CI fails on Zeth and Zecale, with the following error (taken from Zeth CI: https://github.com/clearmatics/zeth/runs/4080321366?check_suite_focus=true)

```

Fetching submodules
  /usr/bin/git submodule sync --recursive
  /usr/bin/git -c protocol.version=2 submodule update --init --force --depth=1 --recursive
  Submodule 'depends/ganache-cli' (http://github.com/clearmatics/ganache-cli) registered for path 'depends/ganache-cli'
  Submodule 'depends/libsnark' (https://github.com/clearmatics/libsnark.git) registered for path 'depends/libsnark'
  Submodule 'depends/libsodium' (https://github.com/jedisct1/libsodium.git) registered for path 'depends/libsodium'
  Cloning into '/home/runner/work/zeth/zeth/depends/ganache-cli'...
  warning: redirecting to https://github.com/clearmatics/ganache-cli/
  Cloning into '/home/runner/work/zeth/zeth/depends/libsnark'...
  Cloning into '/home/runner/work/zeth/zeth/depends/libsodium'...
  warning: redirecting to https://github.com/clearmatics/ganache-cli/
  warning: redirecting to https://github.com/clearmatics/ganache-cli/
  From http://github.com/clearmatics/ganache-cli
   * branch            3b6ba1adf0f7ad08bc46171370fe29bd1d52ecab -> FETCH_HEAD
  Submodule path 'depends/ganache-cli': checked out '3b6ba1adf0f7ad08bc46171370fe29bd1d52ecab'
  From https://github.com/clearmatics/libsnark
   * branch            73a3cef30745f50bc7cd494826eb216518993ac3 -> FETCH_HEAD
  Submodule path 'depends/libsnark': checked out '73a3cef30745f50bc7cd494826eb216518993ac3'
  Submodule 'depends/ate-pairing' (git://github.com/herumi/ate-pairing.git) registered for path 'depends/libsnark/depends/ate-pairing'
  Submodule 'depends/libff' (https://github.com/clearmatics/libff.git) registered for path 'depends/libsnark/depends/libff'
  Submodule 'depends/libfqfft' (https://github.com/clearmatics/libfqfft.git) registered for path 'depends/libsnark/depends/libfqfft'
  Submodule 'depends/libsnark-supercop' (git://github.com/mbbarbosa/libsnark-supercop.git) registered for path 'depends/libsnark/depends/libsnark-supercop'
  Submodule 'depends/xbyak' (git://github.com/herumi/xbyak.git) registered for path 'depends/libsnark/depends/xbyak'
  Cloning into '/home/runner/work/zeth/zeth/depends/libsnark/depends/ate-pairing'...
  Error: fatal: remote error: 
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  Error: fatal: clone of 'git://github.com/herumi/ate-pairing.git' into submodule path '/home/runner/work/zeth/zeth/depends/libsnark/depends/ate-pairing' failed
  Failed to clone 'depends/ate-pairing'. Retry scheduled
  Cloning into '/home/runner/work/zeth/zeth/depends/libsnark/depends/libff'...
  Cloning into '/home/runner/work/zeth/zeth/depends/libsnark/depends/libfqfft'...
  Cloning into '/home/runner/work/zeth/zeth/depends/libsnark/depends/libsnark-supercop'...
  Error: fatal: remote error: 
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
  Error: fatal: clone of 'git://github.com/mbbarbosa/libsnark-supercop.git' into submodule path '/home/runner/work/zeth/zeth/depends/libsnark/depends/libsnark-supercop' failed
  Failed to clone 'depends/libsnark-supercop'. Retry scheduled
  Cloning into '/home/runner/work/zeth/zeth/depends/libsnark/depends/xbyak'...
  Error: fatal: remote error: 
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

By looking at: https://github.blog/2021-09-01-improving-git-protocol-security-github/ today (2nd of November 2021) is the first brownout (see: https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective), justifying the CI failure.

A fix is to simply switch the URLs to a supported format: https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting. This is what this PR does.