### PR TITLE
Pairing params name (depends on #71)

### DIFF
--- a/libff/algebra/curves/alt_bn128/alt_bn128_pp.cpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_pp.cpp
@@ -10,6 +10,8 @@
 namespace libff
 {
 
+const std::string alt_bn128_pp::name("alt_bn128");
+
 void alt_bn128_pp::init_public_params() { init_alt_bn128_params(); }
 
 alt_bn128_GT alt_bn128_pp::final_exponentiation(const alt_bn128_Fq12 &elt)

--- a/libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp
+++ b/libff/algebra/curves/alt_bn128/alt_bn128_pp.hpp
@@ -19,6 +19,8 @@ namespace libff
 class alt_bn128_pp
 {
 public:
+    static const std::string name;
+
     typedef alt_bn128_Fr Fp_type;
     typedef alt_bn128_G1 G1_type;
     typedef alt_bn128_G2 G2_type;

--- a/libff/algebra/curves/bls12_377/bls12_377_pp.cpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_pp.cpp
@@ -10,6 +10,8 @@
 namespace libff
 {
 
+const std::string bls12_377_pp::name("bls12_377");
+
 void bls12_377_pp::init_public_params() { init_bls12_377_params(); }
 
 bls12_377_GT bls12_377_pp::final_exponentiation(const bls12_377_Fq12 &elt)

--- a/libff/algebra/curves/bls12_377/bls12_377_pp.hpp
+++ b/libff/algebra/curves/bls12_377/bls12_377_pp.hpp
@@ -19,6 +19,8 @@ namespace libff
 class bls12_377_pp
 {
 public:
+    static const std::string name;
+
     typedef bls12_377_Fr Fp_type;
     typedef bls12_377_G1 G1_type;
     typedef bls12_377_G2 G2_type;

--- a/libff/algebra/curves/bls12_381/bls12_381_pp.cpp
+++ b/libff/algebra/curves/bls12_381/bls12_381_pp.cpp
@@ -3,6 +3,8 @@
 namespace libff
 {
 
+const std::string bls12_381_pp::name("bls12_381");
+
 void bls12_381_pp::init_public_params() { init_bls12_381_params(); }
 
 bls12_381_GT bls12_381_pp::final_exponentiation(const bls12_381_Fq12 &elt)

--- a/libff/algebra/curves/bls12_381/bls12_381_pp.hpp
+++ b/libff/algebra/curves/bls12_381/bls12_381_pp.hpp
@@ -19,6 +19,8 @@ namespace libff
 class bls12_381_pp
 {
 public:
+    static const std::string name;
+
     typedef bls12_381_Fr Fp_type;
     typedef bls12_381_G1 G1_type;
     typedef bls12_381_G2 G2_type;

--- a/libff/algebra/curves/bn128/bn128_pp.cpp
+++ b/libff/algebra/curves/bn128/bn128_pp.cpp
@@ -11,6 +11,8 @@
 namespace libff
 {
 
+const std::string bn128_pp::name("bn128");
+
 void bn128_pp::init_public_params() { init_bn128_params(); }
 
 bn128_GT bn128_pp::final_exponentiation(const bn128_GT &elt)

--- a/libff/algebra/curves/bn128/bn128_pp.hpp
+++ b/libff/algebra/curves/bn128/bn128_pp.hpp
@@ -20,6 +20,8 @@ namespace libff
 class bn128_pp
 {
 public:
+    static const std::string name;
+
     typedef bn128_Fr Fp_type;
     typedef bn128_G1 G1_type;
     typedef bn128_G2 G2_type;

--- a/libff/algebra/curves/bw6_761/bw6_761_pp.cpp
+++ b/libff/algebra/curves/bw6_761/bw6_761_pp.cpp
@@ -3,6 +3,8 @@
 namespace libff
 {
 
+const std::string bw6_761_pp::name("bw6_761");
+
 void bw6_761_pp::init_public_params() { init_bw6_761_params(); }
 
 bw6_761_GT bw6_761_pp::final_exponentiation(const bw6_761_Fq6 &elt)

--- a/libff/algebra/curves/bw6_761/bw6_761_pp.hpp
+++ b/libff/algebra/curves/bw6_761/bw6_761_pp.hpp
@@ -13,6 +13,8 @@ namespace libff
 class bw6_761_pp
 {
 public:
+    static const std::string name;
+
     typedef bw6_761_Fr Fp_type;
     typedef bw6_761_G1 G1_type;
     typedef bw6_761_G2 G2_type;

--- a/libff/algebra/curves/edwards/edwards_pp.cpp
+++ b/libff/algebra/curves/edwards/edwards_pp.cpp
@@ -10,6 +10,8 @@
 namespace libff
 {
 
+const std::string edwards_pp::name("edwards");
+
 void edwards_pp::init_public_params() { init_edwards_params(); }
 
 edwards_GT edwards_pp::final_exponentiation(const edwards_Fq6 &elt)

--- a/libff/algebra/curves/edwards/edwards_pp.hpp
+++ b/libff/algebra/curves/edwards/edwards_pp.hpp
@@ -19,6 +19,8 @@ namespace libff
 class edwards_pp
 {
 public:
+    static const std::string name;
+
     typedef edwards_Fr Fp_type;
     typedef edwards_G1 G1_type;
     typedef edwards_G2 G2_type;

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pp.cpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pp.cpp
@@ -16,6 +16,8 @@
 namespace libff
 {
 
+const std::string mnt4_pp::name("mnt4");
+
 void mnt4_pp::init_public_params() { init_mnt4_params(); }
 
 mnt4_GT mnt4_pp::final_exponentiation(const mnt4_Fq4 &elt)

--- a/libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp
+++ b/libff/algebra/curves/mnt/mnt4/mnt4_pp.hpp
@@ -24,6 +24,8 @@ namespace libff
 class mnt4_pp
 {
 public:
+    static const std::string name;
+
     typedef mnt4_Fr Fp_type;
     typedef mnt4_G1 G1_type;
     typedef mnt4_G2 G2_type;

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pp.cpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pp.cpp
@@ -16,6 +16,8 @@
 namespace libff
 {
 
+const std::string mnt6_pp::name("mnt6");
+
 void mnt6_pp::init_public_params() { init_mnt6_params(); }
 
 mnt6_GT mnt6_pp::final_exponentiation(const mnt6_Fq6 &elt)

--- a/libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp
+++ b/libff/algebra/curves/mnt/mnt6/mnt6_pp.hpp
@@ -24,6 +24,8 @@ namespace libff
 class mnt6_pp
 {
 public:
+    static const std::string name;
+
     typedef mnt6_Fr Fp_type;
     typedef mnt6_G1 G1_type;
     typedef mnt6_G2 G2_type;

--- a/libff/algebra/curves/public_params.hpp
+++ b/libff/algebra/curves/public_params.hpp
@@ -27,7 +27,9 @@ namespace libff
 ///    Fqk_type
 ///    GT_type
 ///
-///  one should also define the following static methods:
+///  one should also define the following static elements and methods:
+///
+///    const std::string name;
 ///
 ///    void init_public_params();
 ///


### PR DESCRIPTION
Add a string name to pairing params.  This is useful when logging, and as a runtime data value that identifies the curve.