### PR TITLE
Add convenience function print_vector

### DIFF
--- a/libff/algebra/fields/field_utils.hpp
+++ b/libff/algebra/fields/field_utils.hpp
@@ -102,6 +102,9 @@ template<
     const bigint<nn> &nmodulus>
 void fp_from_fp(Fp_model<wn, wmodulus> &wfp, const Fp_model<nn, nmodulus> &nfp);
 
+/// print the elements of a vector
+template<typename FieldT> void print_vector(const std::vector<FieldT> &v);
+
 } // namespace libff
 
 #include <libff/algebra/fields/field_utils.tcc>

--- a/libff/algebra/fields/field_utils.tcc
+++ b/libff/algebra/fields/field_utils.tcc
@@ -461,6 +461,14 @@ void fp_from_fp(Fp_model<wn, wmodulus> &wfp, const Fp_model<nn, nmodulus> &nfp)
     wfp = Fp_model<wn, wmodulus>(wint);
 }
 
+template<typename FieldT> void print_vector(const std::vector<FieldT> &v)
+{
+    for (size_t i = 0; i < v.size(); ++i) {
+        printf("[%2d]: ", (int)i);
+        v[i].print();
+    }
+}
+
 } // namespace libff
 
 #endif // FIELD_UTILS_TCC_


### PR DESCRIPTION
Added function `print_vector` (originally from clearmatics/libsnark.  Related to #70.